### PR TITLE
feat(admin): add automatic model discovery for SQLAdmin

### DIFF
--- a/template/{{cookiecutter.project_slug}}/backend/app/admin.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/admin.py
@@ -1,9 +1,11 @@
 {%- if cookiecutter.enable_admin_panel and cookiecutter.use_postgresql %}
-"""SQLAdmin configuration."""
+"""SQLAdmin configuration with automatic model discovery."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
-from sqlalchemy import create_engine
+from sqlalchemy import String, inspect
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase
 from sqladmin import Admin, ModelView
 {%- if cookiecutter.admin_require_auth %}
 from sqladmin.authentication import AuthenticationBackend
@@ -14,6 +16,7 @@ from app.core.config import settings
 {%- if cookiecutter.admin_require_auth %}
 from app.core.security import verify_password
 {%- endif %}
+from app.db.base import Base
 from app.db.models.user import User
 {%- if cookiecutter.enable_session_management %}
 from app.db.models.session import Session
@@ -28,8 +31,288 @@ from app.db.models.conversation import Conversation, Message, ToolCall
 from app.db.models.webhook import Webhook, WebhookDelivery
 {%- endif %}
 
+
+# Columns that should be excluded from forms (sensitive data)
+SENSITIVE_COLUMN_PATTERNS: list[str] = [
+    "password",
+    "hashed_password",
+    "secret",
+    "token",
+    "api_key",
+    "refresh_token",
+]
+
+# Columns that should be searchable by default (string columns)
+SEARCHABLE_COLUMN_TYPES: tuple[type, ...] = (String,)
+
+# Columns that are auto-generated and should be excluded from create/edit forms
+AUTO_GENERATED_COLUMNS: list[str] = [
+    "created_at",
+    "updated_at",
+]
+
+# Model icons mapping (model name -> Font Awesome icon)
+MODEL_ICONS: dict[str, str] = {
+    "User": "fa-solid fa-user",
+    "Session": "fa-solid fa-key",
+    "Item": "fa-solid fa-box",
+    "Conversation": "fa-solid fa-comments",
+    "Message": "fa-solid fa-message",
+    "ToolCall": "fa-solid fa-wrench",
+    "Webhook": "fa-solid fa-link",
+    "WebhookDelivery": "fa-solid fa-paper-plane",
+}
+
+
+def discover_models(base: type[DeclarativeBase]) -> list[type]:
+    """Discover all SQLAlchemy models registered with the given Base.
+
+    Args:
+        base: The SQLAlchemy DeclarativeBase class.
+
+    Returns:
+        List of model classes that inherit from the Base.
+    """
+    return [mapper.class_ for mapper in base.registry.mappers]
+
+
+def get_model_columns(model: type) -> list[str]:
+    """Get all column names from a SQLAlchemy model.
+
+    Args:
+        model: The SQLAlchemy model class.
+
+    Returns:
+        List of column names.
+    """
+    mapper = inspect(model)
+    return [column.key for column in mapper.columns]
+
+
+def get_searchable_columns(model: type) -> list[str]:
+    """Get columns suitable for searching (String type columns).
+
+    Args:
+        model: The SQLAlchemy model class.
+
+    Returns:
+        List of searchable column names.
+    """
+    mapper = inspect(model)
+    searchable = []
+    for column in mapper.columns:
+        # Include String columns that are not sensitive
+        is_searchable_type = isinstance(column.type, SEARCHABLE_COLUMN_TYPES)
+        is_sensitive = any(pattern in column.key.lower() for pattern in SENSITIVE_COLUMN_PATTERNS)
+        if is_searchable_type and not is_sensitive:
+            searchable.append(column.key)
+    return searchable
+
+
+def get_sortable_columns(model: type) -> list[str]:
+    """Get columns suitable for sorting.
+
+    Args:
+        model: The SQLAlchemy model class.
+
+    Returns:
+        List of sortable column names.
+    """
+    mapper = inspect(model)
+    return [column.key for column in mapper.columns]
+
+
+def get_form_excluded_columns(model: type) -> list[str]:
+    """Get columns that should be excluded from create/edit forms.
+
+    Excludes sensitive columns and auto-generated columns.
+
+    Args:
+        model: The SQLAlchemy model class.
+
+    Returns:
+        List of column names to exclude from forms.
+    """
+    excluded = []
+    for column_name in get_model_columns(model):
+        # Exclude sensitive columns
+        if any(pattern in column_name.lower() for pattern in SENSITIVE_COLUMN_PATTERNS):
+            excluded.append(column_name)
+        # Exclude auto-generated columns
+        elif column_name in AUTO_GENERATED_COLUMNS:
+            excluded.append(column_name)
+    return excluded
+
+
+def pluralize(name: str) -> str:
+    """Simple pluralization for model names.
+
+    Args:
+        name: Singular name.
+
+    Returns:
+        Pluralized name.
+    """
+    if name.endswith("y"):
+        return name[:-1] + "ies"
+    elif name.endswith("s") or name.endswith("x") or name.endswith("ch") or name.endswith("sh"):
+        return name + "es"
+    return name + "s"
+
+
+def create_model_admin(
+    model: type,
+    *,
+    name: str | None = None,
+    name_plural: str | None = None,
+    icon: str | None = None,
+    column_list: list[Any] | None = None,
+    column_searchable_list: list[Any] | None = None,
+    column_sortable_list: list[Any] | None = None,
+    form_excluded_columns: list[Any] | None = None,
+    can_create: bool = True,
+    can_edit: bool = True,
+    can_delete: bool = True,
+    can_view_details: bool = True,
+) -> type[ModelView]:
+    """Dynamically create a ModelView class for a SQLAlchemy model.
+
+    Args:
+        model: The SQLAlchemy model class.
+        name: Display name (defaults to model class name).
+        name_plural: Plural display name (defaults to auto-pluralized name).
+        icon: Font Awesome icon class.
+        column_list: Columns to display in list view.
+        column_searchable_list: Columns to enable search on.
+        column_sortable_list: Columns to enable sorting on.
+        form_excluded_columns: Columns to exclude from forms.
+        can_create: Allow creating new records.
+        can_edit: Allow editing records.
+        can_delete: Allow deleting records.
+        can_view_details: Allow viewing record details.
+
+    Returns:
+        A dynamically created ModelView subclass.
+    """
+    import types
+
+    model_name = model.__name__
+
+    # Use provided values or generate defaults
+    _name = name or model_name
+    _name_plural = name_plural or pluralize(_name)
+    _icon = icon or MODEL_ICONS.get(model_name, "fa-solid fa-database")
+
+    # Get column attributes from the model
+    _column_list = column_list
+    if _column_list is None:
+        columns = get_model_columns(model)
+        _column_list = [getattr(model, col) for col in columns if hasattr(model, col)]
+
+    _column_searchable_list = column_searchable_list
+    if _column_searchable_list is None:
+        searchable = get_searchable_columns(model)
+        _column_searchable_list = [getattr(model, col) for col in searchable if hasattr(model, col)]
+
+    _column_sortable_list = column_sortable_list
+    if _column_sortable_list is None:
+        sortable = get_sortable_columns(model)
+        _column_sortable_list = [getattr(model, col) for col in sortable if hasattr(model, col)]
+
+    _form_excluded_columns = form_excluded_columns
+    if _form_excluded_columns is None:
+        excluded = get_form_excluded_columns(model)
+        _form_excluded_columns = [getattr(model, col) for col in excluded if hasattr(model, col)]
+
+    # Create class attributes in the exec_body callback
+    def exec_body(ns: dict[str, Any]) -> None:
+        ns["name"] = _name
+        ns["name_plural"] = _name_plural
+        ns["icon"] = _icon
+        ns["column_list"] = _column_list
+        ns["column_searchable_list"] = _column_searchable_list
+        ns["column_sortable_list"] = _column_sortable_list
+        ns["form_excluded_columns"] = _form_excluded_columns
+        ns["can_create"] = can_create
+        ns["can_edit"] = can_edit
+        ns["can_delete"] = can_delete
+        ns["can_view_details"] = can_view_details
+        # Add ClassVar type hints for sqladmin compatibility
+        ns["__annotations__"] = {
+            "column_list": ClassVar,
+            "column_searchable_list": ClassVar,
+            "column_sortable_list": ClassVar,
+            "form_excluded_columns": ClassVar,
+            "can_create": ClassVar,
+            "can_edit": ClassVar,
+            "can_delete": ClassVar,
+            "can_view_details": ClassVar,
+        }
+
+    # Create the class using types.new_class to properly pass model kwarg to metaclass
+    class_name = f"{model_name}Admin"
+    admin_class = types.new_class(
+        class_name,
+        (ModelView,),
+        {"model": model},  # Pass model to metaclass
+        exec_body,
+    )
+
+    return admin_class  # type: ignore[return-value]
+
+
+def register_models_auto(
+    admin: Admin,
+    base: type[DeclarativeBase],
+    *,
+    exclude_models: list[type] | None = None,
+    custom_configs: dict[type, dict[str, Any]] | None = None,
+) -> list[type[ModelView]]:
+    """Auto-discover and register all models with the admin panel.
+
+    Args:
+        admin: The SQLAdmin instance.
+        base: The SQLAlchemy DeclarativeBase class.
+        exclude_models: Models to exclude from auto-registration.
+        custom_configs: Custom configuration overrides per model.
+
+    Returns:
+        List of registered ModelView classes.
+    """
+    exclude_models = exclude_models or []
+    custom_configs = custom_configs or {}
+
+    registered_views: list[type[ModelView]] = []
+    models = discover_models(base)
+
+    for model in models:
+        if model in exclude_models:
+            continue
+
+        # Get custom config for this model if provided
+        config = custom_configs.get(model, {})
+
+        # Create and register the admin view
+        admin_class = create_model_admin(model, **config)
+        admin.add_view(admin_class)
+        registered_views.append(admin_class)
+
+    return registered_views
+
+
 # SQLAdmin requires a synchronous engine
-sync_engine = create_engine(settings.DATABASE_URL_SYNC, echo=settings.DEBUG)
+_sync_engine: Engine | None = None
+
+
+def get_sync_engine() -> Engine:
+    """Get or create the synchronous engine for SQLAdmin."""
+    global _sync_engine
+    if _sync_engine is None:
+        from sqlalchemy import create_engine
+
+        _sync_engine = create_engine(settings.DATABASE_URL_SYNC, echo=settings.DEBUG)
+    return _sync_engine
+
 
 {%- if cookiecutter.admin_require_auth %}
 
@@ -52,7 +335,7 @@ class AdminAuth(AuthenticationBackend):
         # Get user from database
         from sqlalchemy.orm import Session as DBSession
 
-        with DBSession(sync_engine) as session:
+        with DBSession(get_sync_engine()) as session:
             user = session.query(User).filter(User.email == email).first()
 
             if (
@@ -81,7 +364,7 @@ class AdminAuth(AuthenticationBackend):
         # Verify user still exists and is superuser
         from sqlalchemy.orm import Session as DBSession
 
-        with DBSession(sync_engine) as session:
+        with DBSession(get_sync_engine()) as session:
             user = session.query(User).filter(User.id == admin_user_id).first()
             if user and user.is_superuser and user.is_active:
                 return True
@@ -92,224 +375,49 @@ class AdminAuth(AuthenticationBackend):
 {%- endif %}
 
 
-# === User Management ===
-
-
-class UserAdmin(ModelView, model=User):  # type: ignore[call-arg]
-    """User admin view."""
-
-    name = "User"
-    name_plural = "Users"
-    icon = "fa-solid fa-user"
-
-    column_list: ClassVar = [
-        User.id,
-        User.email,
-        User.full_name,
-        User.is_active,
-        User.is_superuser,
-        User.role,
-        User.created_at,
-    ]
-    column_searchable_list: ClassVar = [User.email, User.full_name]
-    column_sortable_list: ClassVar = [User.id, User.email, User.is_active, User.created_at]
-    form_excluded_columns: ClassVar = [User.hashed_password, User.created_at, User.updated_at]
-    can_create: ClassVar = True
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
-
+CUSTOM_MODEL_CONFIGS: dict[type, dict[str, Any]] = {
+    User: {
+        "icon": "fa-solid fa-user",
+        "form_excluded_columns": [User.hashed_password, User.created_at, User.updated_at],
+    },
 {%- if cookiecutter.enable_session_management %}
-
-
-class SessionAdmin(ModelView, model=Session):  # type: ignore[call-arg]
-    """Session admin view."""
-
-    name = "Session"
-    name_plural = "Sessions"
-    icon = "fa-solid fa-key"
-
-    column_list: ClassVar = [
-        Session.id,
-        Session.user_id,
-        Session.device_name,
-        Session.device_type,
-        Session.ip_address,
-        Session.is_active,
-        Session.created_at,
-        Session.last_used_at,
-    ]
-    column_searchable_list: ClassVar = [Session.device_name, Session.ip_address]
-    column_sortable_list: ClassVar = [Session.id, Session.created_at, Session.last_used_at]
-    form_excluded_columns: ClassVar = [Session.refresh_token_hash]
-    can_create: ClassVar = False  # Sessions are created via login
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
+    Session: {
+        "icon": "fa-solid fa-key",
+        "form_excluded_columns": [Session.refresh_token_hash],
+        "can_create": False,  # Sessions are created via login
+    },
 {%- endif %}
-
-{%- if cookiecutter.include_example_crud %}
-
-
-# === Items (Example CRUD) ===
-
-
-class ItemAdmin(ModelView, model=Item):  # type: ignore[call-arg]
-    """Item admin view."""
-
-    name = "Item"
-    name_plural = "Items"
-    icon = "fa-solid fa-box"
-
-    column_list: ClassVar = [
-        Item.id,
-        Item.title,
-        Item.is_active,
-        Item.created_at,
-    ]
-    column_searchable_list: ClassVar = [Item.title, Item.description]
-    column_sortable_list: ClassVar = [Item.id, Item.title, Item.created_at]
-    can_create: ClassVar = True
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
-{%- endif %}
-
 {%- if cookiecutter.enable_conversation_persistence %}
-
-
-# === AI Conversations ===
-
-
-class ConversationAdmin(ModelView, model=Conversation):  # type: ignore[call-arg]
-    """Conversation admin view."""
-
-    name = "Conversation"
-    name_plural = "Conversations"
-    icon = "fa-solid fa-comments"
-
-    column_list: ClassVar = [
-        Conversation.id,
-        Conversation.user_id,
-        Conversation.title,
-        Conversation.is_archived,
-        Conversation.created_at,
-    ]
-    column_searchable_list: ClassVar = [Conversation.title]
-    column_sortable_list: ClassVar = [Conversation.id, Conversation.created_at]
-    can_create: ClassVar = True
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
-
-
-class MessageAdmin(ModelView, model=Message):  # type: ignore[call-arg]
-    """Message admin view."""
-
-    name = "Message"
-    name_plural = "Messages"
-    icon = "fa-solid fa-message"
-
-    column_list: ClassVar = [
-        Message.id,
-        Message.conversation_id,
-        Message.role,
-        Message.model_name,
-        Message.tokens_used,
-        Message.created_at,
-    ]
-    column_searchable_list: ClassVar = [Message.content, Message.role]
-    column_sortable_list: ClassVar = [Message.id, Message.role, Message.created_at]
-    can_create: ClassVar = True
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
-
-
-class ToolCallAdmin(ModelView, model=ToolCall):  # type: ignore[call-arg]
-    """ToolCall admin view."""
-
-    name = "Tool Call"
-    name_plural = "Tool Calls"
-    icon = "fa-solid fa-wrench"
-
-    column_list: ClassVar = [
-        ToolCall.id,
-        ToolCall.message_id,
-        ToolCall.tool_name,
-        ToolCall.status,
-        ToolCall.duration_ms,
-        ToolCall.started_at,
-    ]
-    column_searchable_list: ClassVar = [ToolCall.tool_name, ToolCall.tool_call_id]
-    column_sortable_list: ClassVar = [ToolCall.id, ToolCall.tool_name, ToolCall.started_at]
-    can_create: ClassVar = False  # Tool calls are created by the agent
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
+    ToolCall: {
+        "icon": "fa-solid fa-wrench",
+        "can_create": False,  # Tool calls are created by the agent
+    },
 {%- endif %}
-
 {%- if cookiecutter.enable_webhooks %}
-
-
-# === Webhooks ===
-
-
-class WebhookAdmin(ModelView, model=Webhook):  # type: ignore[call-arg]
-    """Webhook admin view."""
-
-    name = "Webhook"
-    name_plural = "Webhooks"
-    icon = "fa-solid fa-link"
-
-    column_list: ClassVar = [
-        Webhook.id,
-        Webhook.name,
-        Webhook.url,
-        Webhook.is_active,
-        Webhook.created_at,
-    ]
-    column_searchable_list: ClassVar = [Webhook.name, Webhook.url]
-    column_sortable_list: ClassVar = [Webhook.id, Webhook.name, Webhook.is_active, Webhook.created_at]
-    form_excluded_columns: ClassVar = [Webhook.secret]  # Hide secret in forms
-    can_create: ClassVar = True
-    can_edit: ClassVar = True
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
-
-
-class WebhookDeliveryAdmin(ModelView, model=WebhookDelivery):  # type: ignore[call-arg]
-    """WebhookDelivery admin view."""
-
-    name = "Webhook Delivery"
-    name_plural = "Webhook Deliveries"
-    icon = "fa-solid fa-paper-plane"
-
-    column_list: ClassVar = [
-        WebhookDelivery.id,
-        WebhookDelivery.webhook_id,
-        WebhookDelivery.event_type,
-        WebhookDelivery.response_status,
-        WebhookDelivery.success,
-        WebhookDelivery.attempt_count,
-        WebhookDelivery.created_at,
-    ]
-    column_searchable_list: ClassVar = [WebhookDelivery.event_type]
-    column_sortable_list: ClassVar = [
-        WebhookDelivery.id,
-        WebhookDelivery.event_type,
-        WebhookDelivery.success,
-        WebhookDelivery.created_at,
-    ]
-    can_create: ClassVar = False  # Deliveries are created by webhook dispatch
-    can_edit: ClassVar = False
-    can_delete: ClassVar = True
-    can_view_details: ClassVar = True
+    Webhook: {
+        "icon": "fa-solid fa-link",
+        "form_excluded_columns": [Webhook.secret],
+    },
+    WebhookDelivery: {
+        "icon": "fa-solid fa-paper-plane",
+        "can_create": False,  # Deliveries are created by webhook dispatch
+        "can_edit": False,
+    },
 {%- endif %}
+}
 
 
-def setup_admin(app):
-    """Setup SQLAdmin for the FastAPI app."""
+def setup_admin(app) -> Admin:
+    """Setup SQLAdmin for the FastAPI app with automatic model discovery.
+
+    Automatically discovers all SQLAlchemy models from the Base registry
+    and creates admin views for them with sensible defaults.
+
+    Custom configurations can be provided in CUSTOM_MODEL_CONFIGS to override
+    default behavior for specific models.
+    """
+    sync_engine = get_sync_engine()
+
     {%- if cookiecutter.admin_require_auth %}
     authentication_backend = AdminAuth(secret_key=settings.SECRET_KEY)
     admin = Admin(
@@ -326,29 +434,12 @@ def setup_admin(app):
     )
     {%- endif %}
 
-    # User management
-    admin.add_view(UserAdmin)
-{%- if cookiecutter.enable_session_management %}
-    admin.add_view(SessionAdmin)
-{%- endif %}
-
-{%- if cookiecutter.include_example_crud %}
-    # Items
-    admin.add_view(ItemAdmin)
-{%- endif %}
-
-{%- if cookiecutter.enable_conversation_persistence %}
-    # AI Conversations
-    admin.add_view(ConversationAdmin)
-    admin.add_view(MessageAdmin)
-    admin.add_view(ToolCallAdmin)
-{%- endif %}
-
-{%- if cookiecutter.enable_webhooks %}
-    # Webhooks
-    admin.add_view(WebhookAdmin)
-    admin.add_view(WebhookDeliveryAdmin)
-{%- endif %}
+    # Auto-register all models from Base with custom configs
+    register_models_auto(
+        admin,
+        Base,
+        custom_configs=CUSTOM_MODEL_CONFIGS,
+    )
 
     return admin
 {%- else %}

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_admin.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_admin.py
@@ -1,0 +1,890 @@
+{%- if cookiecutter.enable_admin_panel and cookiecutter.use_postgresql %}
+"""Tests for admin panel with automatic model discovery."""
+
+from typing import ClassVar
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+from sqlalchemy import Boolean, Integer, String, DateTime, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from app.admin import (
+    SENSITIVE_COLUMN_PATTERNS,
+    AUTO_GENERATED_COLUMNS,
+    MODEL_ICONS,
+    discover_models,
+    get_model_columns,
+    get_searchable_columns,
+    get_sortable_columns,
+    get_form_excluded_columns,
+    pluralize,
+    create_model_admin,
+    register_models_auto,
+    get_sync_engine,
+    setup_admin,
+)
+{%- if cookiecutter.admin_require_auth %}
+from app.admin import AdminAuth
+{%- endif %}
+
+
+class MockBase(DeclarativeBase):
+    """Mock base class for testing."""
+
+    pass
+
+
+class MockUser(MockBase):
+    """Mock user model for testing."""
+
+    __tablename__ = "mock_users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    full_name: Mapped[str] = mapped_column(String(255), nullable=True)
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[str] = mapped_column(DateTime, nullable=True)
+    updated_at: Mapped[str] = mapped_column(DateTime, nullable=True)
+
+
+class MockItem(MockBase):
+    """Mock item model for testing."""
+
+    __tablename__ = "mock_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=True)
+    price: Mapped[int] = mapped_column(Integer, nullable=True)
+
+
+class MockSession(MockBase):
+    """Mock session model with sensitive columns."""
+
+    __tablename__ = "mock_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    refresh_token_hash: Mapped[str] = mapped_column(String(255), nullable=True)
+    api_key: Mapped[str] = mapped_column(String(255), nullable=True)
+    secret: Mapped[str] = mapped_column(String(255), nullable=True)
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_sensitive_column_patterns_exist(self):
+        """Test sensitive column patterns are defined."""
+        assert isinstance(SENSITIVE_COLUMN_PATTERNS, list)
+        assert "password" in SENSITIVE_COLUMN_PATTERNS
+        assert "hashed_password" in SENSITIVE_COLUMN_PATTERNS
+        assert "secret" in SENSITIVE_COLUMN_PATTERNS
+        assert "token" in SENSITIVE_COLUMN_PATTERNS
+        assert "api_key" in SENSITIVE_COLUMN_PATTERNS
+
+    def test_auto_generated_columns_exist(self):
+        """Test auto-generated columns are defined."""
+        assert isinstance(AUTO_GENERATED_COLUMNS, list)
+        assert "created_at" in AUTO_GENERATED_COLUMNS
+        assert "updated_at" in AUTO_GENERATED_COLUMNS
+
+    def test_model_icons_exist(self):
+        """Test model icons mapping is defined."""
+        assert isinstance(MODEL_ICONS, dict)
+        assert "User" in MODEL_ICONS
+        assert MODEL_ICONS["User"] == "fa-solid fa-user"
+
+
+class TestDiscoverModels:
+    """Tests for discover_models function."""
+
+    def test_discovers_all_registered_models(self):
+        """Test that discover_models finds all models in the registry."""
+        models = discover_models(MockBase)
+        model_names = [m.__name__ for m in models]
+
+        assert "MockUser" in model_names
+        assert "MockItem" in model_names
+        assert "MockSession" in model_names
+
+    def test_returns_list(self):
+        """Test that discover_models returns a list."""
+        models = discover_models(MockBase)
+        assert isinstance(models, list)
+
+    def test_returns_model_classes(self):
+        """Test that discovered items are model classes."""
+        models = discover_models(MockBase)
+        for model in models:
+            assert hasattr(model, "__tablename__")
+
+
+class TestGetModelColumns:
+    """Tests for get_model_columns function."""
+
+    def test_returns_all_columns(self):
+        """Test that all columns are returned."""
+        columns = get_model_columns(MockUser)
+
+        assert "id" in columns
+        assert "email" in columns
+        assert "full_name" in columns
+        assert "hashed_password" in columns
+        assert "is_active" in columns
+        assert "created_at" in columns
+        assert "updated_at" in columns
+
+    def test_returns_list_of_strings(self):
+        """Test that column names are strings."""
+        columns = get_model_columns(MockItem)
+
+        assert isinstance(columns, list)
+        for col in columns:
+            assert isinstance(col, str)
+
+
+class TestGetSearchableColumns:
+    """Tests for get_searchable_columns function."""
+
+    def test_returns_string_columns(self):
+        """Test that string columns are included."""
+        columns = get_searchable_columns(MockUser)
+
+        assert "email" in columns
+        assert "full_name" in columns
+
+    def test_excludes_sensitive_columns(self):
+        """Test that sensitive columns are excluded."""
+        columns = get_searchable_columns(MockUser)
+
+        assert "hashed_password" not in columns
+
+    def test_excludes_non_string_columns(self):
+        """Test that non-string columns are excluded."""
+        columns = get_searchable_columns(MockUser)
+
+        assert "id" not in columns
+        assert "is_active" not in columns
+
+    def test_excludes_multiple_sensitive_patterns(self):
+        """Test that all sensitive patterns are excluded."""
+        columns = get_searchable_columns(MockSession)
+
+        assert "refresh_token_hash" not in columns
+        assert "api_key" not in columns
+        assert "secret" not in columns
+
+
+class TestGetSortableColumns:
+    """Tests for get_sortable_columns function."""
+
+    def test_returns_all_columns(self):
+        """Test that all columns are returned as sortable."""
+        columns = get_sortable_columns(MockItem)
+
+        assert "id" in columns
+        assert "title" in columns
+        assert "description" in columns
+        assert "price" in columns
+
+    def test_returns_list(self):
+        """Test that a list is returned."""
+        columns = get_sortable_columns(MockUser)
+
+        assert isinstance(columns, list)
+
+
+# =============================================================================
+# Tests for get_form_excluded_columns
+# =============================================================================
+
+
+class TestGetFormExcludedColumns:
+    """Tests for get_form_excluded_columns function."""
+
+    def test_excludes_sensitive_columns(self):
+        """Test that sensitive columns are excluded from forms."""
+        columns = get_form_excluded_columns(MockUser)
+
+        assert "hashed_password" in columns
+
+    def test_excludes_auto_generated_columns(self):
+        """Test that auto-generated columns are excluded from forms."""
+        columns = get_form_excluded_columns(MockUser)
+
+        assert "created_at" in columns
+        assert "updated_at" in columns
+
+    def test_does_not_exclude_regular_columns(self):
+        """Test that regular columns are not excluded."""
+        columns = get_form_excluded_columns(MockUser)
+
+        assert "email" not in columns
+        assert "full_name" not in columns
+        assert "is_active" not in columns
+
+    def test_excludes_all_sensitive_patterns(self):
+        """Test that all sensitive patterns are matched."""
+        columns = get_form_excluded_columns(MockSession)
+
+        assert "refresh_token_hash" in columns
+        assert "api_key" in columns
+        assert "secret" in columns
+
+
+# =============================================================================
+# Tests for pluralize
+# =============================================================================
+
+
+class TestPluralize:
+    """Tests for pluralize function."""
+
+    def test_regular_pluralization(self):
+        """Test regular word pluralization (add 's')."""
+        assert pluralize("User") == "Users"
+        assert pluralize("Item") == "Items"
+        assert pluralize("Model") == "Models"
+
+    def test_words_ending_in_y(self):
+        """Test words ending in 'y' (change to 'ies')."""
+        assert pluralize("Category") == "Categories"
+        assert pluralize("Delivery") == "Deliveries"
+        assert pluralize("Entry") == "Entries"
+
+    def test_words_ending_in_s(self):
+        """Test words ending in 's' (add 'es')."""
+        assert pluralize("Address") == "Addresses"
+        assert pluralize("Class") == "Classes"
+
+    def test_words_ending_in_x(self):
+        """Test words ending in 'x' (add 'es')."""
+        assert pluralize("Box") == "Boxes"
+        assert pluralize("Tax") == "Taxes"
+
+    def test_words_ending_in_ch(self):
+        """Test words ending in 'ch' (add 'es')."""
+        assert pluralize("Match") == "Matches"
+        assert pluralize("Batch") == "Batches"
+
+    def test_words_ending_in_sh(self):
+        """Test words ending in 'sh' (add 'es')."""
+        assert pluralize("Dish") == "Dishes"
+        assert pluralize("Wish") == "Wishes"
+
+
+# =============================================================================
+# Tests for create_model_admin
+# =============================================================================
+
+
+class TestCreateModelAdmin:
+    """Tests for create_model_admin function."""
+
+    def test_creates_model_view_class(self):
+        """Test that a ModelView subclass is created."""
+        from sqladmin import ModelView
+
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class is not None
+        assert issubclass(admin_class, ModelView)
+
+    def test_binds_model_via_metaclass(self):
+        """Test that the model is properly bound via the metaclass."""
+        admin_class = create_model_admin(MockItem)
+
+        # The model should be accessible after metaclass processing
+        assert hasattr(admin_class, "model")
+        assert admin_class.model == MockItem
+
+    def test_generates_class_name(self):
+        """Test that the class name is generated correctly."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.__name__ == "MockItemAdmin"
+
+    def test_sets_display_name(self):
+        """Test that the display name is set."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.name == "MockItem"
+
+    def test_sets_plural_name(self):
+        """Test that the plural name is set."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.name_plural == "MockItems"
+
+    def test_custom_name_override(self):
+        """Test that custom name can be provided."""
+        admin_class = create_model_admin(MockItem, name="Product")
+
+        assert admin_class.name == "Product"
+
+    def test_custom_name_plural_override(self):
+        """Test that custom plural name can be provided."""
+        admin_class = create_model_admin(MockItem, name_plural="Products")
+
+        assert admin_class.name_plural == "Products"
+
+    def test_sets_icon_from_mapping(self):
+        """Test that icon is set from MODEL_ICONS mapping."""
+        admin_class = create_model_admin(MockUser)
+
+        # MockUser won't be in MODEL_ICONS, so it should get default
+        assert admin_class.icon == "fa-solid fa-database"
+
+    def test_custom_icon_override(self):
+        """Test that custom icon can be provided."""
+        admin_class = create_model_admin(MockItem, icon="fa-solid fa-star")
+
+        assert admin_class.icon == "fa-solid fa-star"
+
+    def test_sets_column_list(self):
+        """Test that column_list is populated."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.column_list is not None
+        assert len(admin_class.column_list) > 0
+
+    def test_custom_column_list(self):
+        """Test that custom column_list can be provided."""
+        admin_class = create_model_admin(
+            MockItem, column_list=[MockItem.id, MockItem.title]
+        )
+
+        assert len(admin_class.column_list) == 2
+
+    def test_sets_searchable_columns(self):
+        """Test that searchable columns are set."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.column_searchable_list is not None
+
+    def test_sets_sortable_columns(self):
+        """Test that sortable columns are set."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.column_sortable_list is not None
+
+    def test_sets_form_excluded_columns(self):
+        """Test that form excluded columns are set."""
+        admin_class = create_model_admin(MockUser)
+
+        assert admin_class.form_excluded_columns is not None
+
+    def test_crud_permissions_default_true(self):
+        """Test that CRUD permissions default to True."""
+        admin_class = create_model_admin(MockItem)
+
+        assert admin_class.can_create is True
+        assert admin_class.can_edit is True
+        assert admin_class.can_delete is True
+        assert admin_class.can_view_details is True
+
+    def test_crud_permissions_can_be_disabled(self):
+        """Test that CRUD permissions can be disabled."""
+        admin_class = create_model_admin(
+            MockItem,
+            can_create=False,
+            can_edit=False,
+            can_delete=False,
+            can_view_details=False,
+        )
+
+        assert admin_class.can_create is False
+        assert admin_class.can_edit is False
+        assert admin_class.can_delete is False
+        assert admin_class.can_view_details is False
+
+
+# =============================================================================
+# Tests for register_models_auto
+# =============================================================================
+
+
+class TestRegisterModelsAuto:
+    """Tests for register_models_auto function."""
+
+    def test_registers_all_models(self):
+        """Test that all models are registered."""
+        mock_admin = MagicMock()
+
+        registered = register_models_auto(mock_admin, MockBase)
+
+        assert len(registered) >= 3  # MockUser, MockItem, MockSession
+        assert mock_admin.add_view.call_count >= 3
+
+    def test_excludes_specified_models(self):
+        """Test that excluded models are not registered."""
+        mock_admin = MagicMock()
+
+        registered = register_models_auto(
+            mock_admin, MockBase, exclude_models=[MockSession]
+        )
+
+        registered_names = [r.__name__ for r in registered]
+        assert "MockSessionAdmin" not in registered_names
+
+    def test_applies_custom_configs(self):
+        """Test that custom configs are applied."""
+        mock_admin = MagicMock()
+        custom_configs = {
+            MockItem: {
+                "can_create": False,
+                "icon": "fa-solid fa-custom",
+            }
+        }
+
+        registered = register_models_auto(
+            mock_admin, MockBase, custom_configs=custom_configs
+        )
+
+        # Find the MockItem admin class
+        item_admin = next(r for r in registered if r.model == MockItem)
+        assert item_admin.can_create is False
+        assert item_admin.icon == "fa-solid fa-custom"
+
+    def test_returns_list_of_model_views(self):
+        """Test that a list of ModelView classes is returned."""
+        from sqladmin import ModelView
+
+        mock_admin = MagicMock()
+
+        registered = register_models_auto(mock_admin, MockBase)
+
+        assert isinstance(registered, list)
+        for admin_class in registered:
+            assert issubclass(admin_class, ModelView)
+
+
+# =============================================================================
+# Tests for get_sync_engine
+# =============================================================================
+
+
+class TestGetSyncEngine:
+    """Tests for get_sync_engine function."""
+
+    @patch("app.admin.create_engine")
+    @patch("app.admin.settings")
+    def test_creates_engine_with_settings(self, mock_settings, mock_create_engine):
+        """Test that engine is created with correct settings."""
+        import app.admin as admin_module
+
+        # Reset the cached engine
+        admin_module._sync_engine = None
+
+        mock_settings.DATABASE_URL_SYNC = "postgresql://test"
+        mock_settings.DEBUG = False
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+
+        engine = get_sync_engine()
+
+        mock_create_engine.assert_called_once_with(
+            "postgresql://test", echo=False
+        )
+        assert engine == mock_engine
+
+        # Reset for other tests
+        admin_module._sync_engine = None
+
+    @patch("app.admin.create_engine")
+    @patch("app.admin.settings")
+    def test_returns_cached_engine(self, mock_settings, mock_create_engine):
+        """Test that engine is cached and reused."""
+        import app.admin as admin_module
+
+        # Reset the cached engine
+        admin_module._sync_engine = None
+
+        mock_settings.DATABASE_URL_SYNC = "postgresql://test"
+        mock_settings.DEBUG = False
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+
+        engine1 = get_sync_engine()
+        engine2 = get_sync_engine()
+
+        # Should only create once
+        mock_create_engine.assert_called_once()
+        assert engine1 is engine2
+
+        # Reset for other tests
+        admin_module._sync_engine = None
+
+
+# =============================================================================
+# Tests for setup_admin
+# =============================================================================
+
+
+class TestSetupAdmin:
+    """Tests for setup_admin function."""
+
+    @patch("app.admin.register_models_auto")
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.Admin")
+    def test_creates_admin_instance(
+        self, mock_admin_class, mock_get_engine, mock_register
+    ):
+        """Test that Admin instance is created."""
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+        mock_admin_instance = MagicMock()
+        mock_admin_class.return_value = mock_admin_instance
+        mock_app = MagicMock()
+
+        result = setup_admin(mock_app)
+
+        mock_admin_class.assert_called_once()
+        assert result == mock_admin_instance
+
+    @patch("app.admin.register_models_auto")
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.Admin")
+    def test_calls_register_models_auto(
+        self, mock_admin_class, mock_get_engine, mock_register
+    ):
+        """Test that register_models_auto is called."""
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+        mock_admin_instance = MagicMock()
+        mock_admin_class.return_value = mock_admin_instance
+        mock_app = MagicMock()
+
+        setup_admin(mock_app)
+
+        mock_register.assert_called_once()
+
+    @patch("app.admin.register_models_auto")
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.Admin")
+    def test_uses_correct_engine(
+        self, mock_admin_class, mock_get_engine, mock_register
+    ):
+        """Test that the sync engine is used."""
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+        mock_admin_instance = MagicMock()
+        mock_admin_class.return_value = mock_admin_instance
+        mock_app = MagicMock()
+
+        setup_admin(mock_app)
+
+        # Check that Admin was called with the engine
+        call_args = mock_admin_class.call_args
+        assert call_args[0][1] == mock_engine
+
+
+{%- if cookiecutter.admin_require_auth %}
+
+
+# =============================================================================
+# Tests for AdminAuth
+# =============================================================================
+
+
+class TestAdminAuth:
+    """Tests for AdminAuth authentication backend."""
+
+    @pytest.fixture
+    def auth_backend(self):
+        """Create an AdminAuth instance for testing."""
+        return AdminAuth(secret_key="test-secret-key")
+
+    @pytest.fixture
+    def mock_request(self):
+        """Create a mock request object."""
+        request = MagicMock()
+        request.session = {}
+        return request
+
+    @pytest.mark.anyio
+    async def test_login_returns_false_for_empty_credentials(
+        self, auth_backend, mock_request
+    ):
+        """Test that login fails with empty credentials."""
+        mock_request.form = AsyncMock(return_value={"username": "", "password": ""})
+
+        result = await auth_backend.login(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_login_returns_false_for_missing_email(
+        self, auth_backend, mock_request
+    ):
+        """Test that login fails with missing email."""
+        mock_request.form = AsyncMock(return_value={"username": None, "password": "pass"})
+
+        result = await auth_backend.login(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_login_returns_false_for_missing_password(
+        self, auth_backend, mock_request
+    ):
+        """Test that login fails with missing password."""
+        mock_request.form = AsyncMock(return_value={"username": "test@test.com", "password": None})
+
+        result = await auth_backend.login(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.verify_password")
+    async def test_login_returns_false_for_nonexistent_user(
+        self, mock_verify, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that login fails for non-existent user."""
+        mock_request.form = AsyncMock(
+            return_value={"username": "nonexistent@test.com", "password": "password"}
+        )
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.login(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.verify_password")
+    async def test_login_returns_false_for_wrong_password(
+        self, mock_verify, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that login fails for wrong password."""
+        mock_request.form = AsyncMock(
+            return_value={"username": "test@test.com", "password": "wrongpassword"}
+        )
+        mock_verify.return_value = False
+
+        mock_user = MagicMock()
+        mock_user.is_superuser = True
+        mock_user.hashed_password = "hashed"
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.login(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.verify_password")
+    async def test_login_returns_false_for_non_superuser(
+        self, mock_verify, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that login fails for non-superuser."""
+        mock_request.form = AsyncMock(
+            return_value={"username": "test@test.com", "password": "password"}
+        )
+        mock_verify.return_value = True
+
+        mock_user = MagicMock()
+        mock_user.is_superuser = False
+        mock_user.hashed_password = "hashed"
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.login(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    @patch("app.admin.verify_password")
+    async def test_login_success_for_valid_superuser(
+        self, mock_verify, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that login succeeds for valid superuser."""
+        mock_request.form = AsyncMock(
+            return_value={"username": "admin@test.com", "password": "password"}
+        )
+        mock_verify.return_value = True
+
+        mock_user = MagicMock()
+        mock_user.id = "user-123"
+        mock_user.email = "admin@test.com"
+        mock_user.is_superuser = True
+        mock_user.hashed_password = "hashed"
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.login(mock_request)
+
+        assert result is True
+        assert mock_request.session["admin_user_id"] == "user-123"
+        assert mock_request.session["admin_email"] == "admin@test.com"
+
+    @pytest.mark.anyio
+    async def test_logout_clears_session(self, auth_backend, mock_request):
+        """Test that logout clears the session."""
+        mock_request.session["admin_user_id"] = "user-123"
+        mock_request.session["admin_email"] = "test@test.com"
+
+        result = await auth_backend.logout(mock_request)
+
+        assert result is True
+        mock_request.session.clear.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_authenticate_returns_false_without_session(
+        self, auth_backend, mock_request
+    ):
+        """Test that authenticate fails without session."""
+        mock_request.session = {}
+
+        result = await auth_backend.authenticate(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    async def test_authenticate_returns_false_for_invalid_user(
+        self, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that authenticate fails for invalid user."""
+        mock_request.session = {"admin_user_id": "user-123"}
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.authenticate(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    async def test_authenticate_returns_false_for_inactive_user(
+        self, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that authenticate fails for inactive user."""
+        mock_request.session = {"admin_user_id": "user-123"}
+
+        mock_user = MagicMock()
+        mock_user.is_superuser = True
+        mock_user.is_active = False
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.authenticate(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    async def test_authenticate_returns_false_for_non_superuser(
+        self, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that authenticate fails for non-superuser."""
+        mock_request.session = {"admin_user_id": "user-123"}
+
+        mock_user = MagicMock()
+        mock_user.is_superuser = False
+        mock_user.is_active = True
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.authenticate(mock_request)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    @patch("app.admin.get_sync_engine")
+    async def test_authenticate_success_for_valid_superuser(
+        self, mock_get_engine, auth_backend, mock_request
+    ):
+        """Test that authenticate succeeds for valid superuser."""
+        mock_request.session = {"admin_user_id": "user-123"}
+
+        mock_user = MagicMock()
+        mock_user.is_superuser = True
+        mock_user.is_active = True
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_engine = MagicMock()
+        mock_get_engine.return_value = mock_engine
+
+        with patch("sqlalchemy.orm.Session") as mock_session_class:
+            mock_session_class.return_value.__enter__ = MagicMock(
+                return_value=mock_session
+            )
+            mock_session_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = await auth_backend.authenticate(mock_request)
+
+        assert result is True
+{%- endif %}
+{%- else %}
+"""Admin panel tests - not configured."""
+{%- endif %}

--- a/uv.lock
+++ b/uv.lock
@@ -279,7 +279,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-fullstack"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
  - Add discover_models() to find all SQLAlchemy models from Base registry
  - Add create_model_admin() using types.new_class for dynamic ModelView creation
  - Auto-detect searchable columns (String types), exclude sensitive fields
  - Support custom per-model configurations via CUSTOM_MODEL_CONFIGS
  - Add comprehensive test suite for admin module
  - Update README with Admin Panel documentation section
  