### PR TITLE
feat: add LangGraph ReAct Agent Support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2026-01-02
+
+### Added
+
+#### LangGraph ReAct Agent Support
+
+- **LangGraph as third AI framework option** alongside PydanticAI and LangChain
+- New `--ai-framework langgraph` CLI option for project creation
+- Interactive prompt includes "LangGraph (ReAct agent)" choice
+- **ReAct (Reasoning + Acting) agent pattern** with graph-based architecture:
+  - Agent node for LLM reasoning and tool decision
+  - Tools node for executing tool calls
+  - Conditional edges for tool execution loop
+  - Memory-based checkpointing for conversation continuity
+- **Full WebSocket streaming support** using `astream()` with dual modes:
+  - `messages` mode for token-level LLM streaming
+  - `updates` mode for node state changes (tool calls/results)
+- **Tool result correlation** - proper `tool_call_id` matching between calls and results
+- New template files:
+  - `app/agents/langgraph_assistant.py` - LangGraphAssistant class with run() and stream()
+  - WebSocket route implementation in `app/api/routes/v1/agent.py`
+- New cookiecutter variable: `use_langgraph`
+- Dependencies for LangGraph projects:
+  - `langchain-core>=0.3.0`
+  - `langchain-openai>=0.3.0` or `langchain-anthropic>=0.3.0`
+  - `langgraph>=0.2.0`
+  - `langgraph-checkpoint>=2.0.0`
+
+### Changed
+
+- **`AIFrameworkType` enum** extended with `LANGGRAPH` value
+- **AI framework prompt** now shows three options: PydanticAI, LangChain, LangGraph
+- **LLM provider validation** - OpenRouter not supported with LangGraph (same as LangChain)
+- **`VARIABLES.md`** updated with `use_langgraph` documentation
+- **Template `CLAUDE.md`** includes LangGraph in stack section
+
 ## [0.1.10] - 2025-12-27
 
 ### Added

--- a/fastapi_gen/config.py
+++ b/fastapi_gen/config.py
@@ -89,6 +89,7 @@ class AIFrameworkType(str, Enum):
 
     PYDANTIC_AI = "pydantic_ai"
     LANGCHAIN = "langchain"
+    LANGGRAPH = "langgraph"
 
 
 class LLMProviderType(str, Enum):
@@ -264,6 +265,12 @@ class ProjectConfig(BaseModel):
         ):
             raise ValueError("OpenRouter is not supported with LangChain")
         if (
+            self.enable_ai_agent
+            and self.ai_framework == AIFrameworkType.LANGGRAPH
+            and self.llm_provider == LLMProviderType.OPENROUTER
+        ):
+            raise ValueError("OpenRouter is not supported with LangGraph")
+        if (
             self.enable_rate_limiting
             and self.rate_limit_storage == RateLimitStorageType.REDIS
             and not self.enable_redis
@@ -345,6 +352,7 @@ class ProjectConfig(BaseModel):
             "ai_framework": self.ai_framework.value,
             "use_pydantic_ai": self.ai_framework == AIFrameworkType.PYDANTIC_AI,
             "use_langchain": self.ai_framework == AIFrameworkType.LANGCHAIN,
+            "use_langgraph": self.ai_framework == AIFrameworkType.LANGGRAPH,
             "llm_provider": self.llm_provider.value,
             "use_openai": self.llm_provider == LLMProviderType.OPENAI,
             "use_anthropic": self.llm_provider == LLMProviderType.ANTHROPIC,

--- a/fastapi_gen/prompts.py
+++ b/fastapi_gen/prompts.py
@@ -530,6 +530,7 @@ def prompt_ai_framework() -> AIFrameworkType:
     choices = [
         questionary.Choice("PydanticAI (recommended)", value=AIFrameworkType.PYDANTIC_AI),
         questionary.Choice("LangChain", value=AIFrameworkType.LANGCHAIN),
+        questionary.Choice("LangGraph (ReAct agent)", value=AIFrameworkType.LANGGRAPH),
     ]
 
     return cast(
@@ -549,7 +550,7 @@ def prompt_llm_provider(ai_framework: AIFrameworkType) -> LLMProviderType:
 
     Args:
         ai_framework: The selected AI framework. OpenRouter is only
-            available for PydanticAI.
+            available for PydanticAI (not LangChain or LangGraph).
     """
     console.print()
     console.print("[bold cyan]LLM Provider[/]")
@@ -560,7 +561,7 @@ def prompt_llm_provider(ai_framework: AIFrameworkType) -> LLMProviderType:
         questionary.Choice("Anthropic (claude-sonnet-4-5)", value=LLMProviderType.ANTHROPIC),
     ]
 
-    # OpenRouter only available for PydanticAI
+    # OpenRouter only available for PydanticAI (not LangChain or LangGraph)
     if ai_framework == AIFrameworkType.PYDANTIC_AI:
         choices.append(
             questionary.Choice("OpenRouter (multi-provider)", value=LLMProviderType.OPENROUTER)

--- a/template/VARIABLES.md
+++ b/template/VARIABLES.md
@@ -187,9 +187,10 @@ These variables are set automatically by the generator.
 | Variable | Type | Default | Description | Dependencies |
 |----------|------|---------|-------------|--------------|
 | `enable_ai_agent` | bool | `false` | Enable AI agent functionality | - |
-| `ai_framework` | enum | `"pydantic_ai"` | AI framework. Values: `pydantic_ai`, `langchain` | Requires `enable_ai_agent` |
+| `ai_framework` | enum | `"pydantic_ai"` | AI framework. Values: `pydantic_ai`, `langchain`, `langgraph` | Requires `enable_ai_agent` |
 | `use_pydantic_ai` | bool | `true` | PydanticAI is selected | Computed from `ai_framework` |
 | `use_langchain` | bool | `false` | LangChain is selected | Computed from `ai_framework` |
+| `use_langgraph` | bool | `false` | LangGraph (ReAct agent) is selected | Computed from `ai_framework` |
 | `llm_provider` | enum | `"openai"` | LLM provider. Values: `openai`, `anthropic`, `openrouter` | Requires `enable_ai_agent` |
 | `use_openai` | bool | `true` | OpenAI is selected | Computed from `llm_provider` |
 | `use_anthropic` | bool | `false` | Anthropic is selected | Computed from `llm_provider` |
@@ -198,7 +199,8 @@ These variables are set automatically by the generator.
 
 **Notes:**
 - PydanticAI uses `iter()` for full event streaming over WebSocket
-- OpenRouter with LangChain is not supported
+- LangGraph implements a ReAct (Reasoning + Acting) agent pattern with graph-based architecture
+- OpenRouter with LangChain or LangGraph is not supported
 
 ---
 

--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -61,6 +61,7 @@
   "ai_framework": "pydantic_ai",
   "use_pydantic_ai": true,
   "use_langchain": false,
+  "use_langgraph": false,
   "llm_provider": "openai",
   "use_openai": true,
   "use_anthropic": false,

--- a/template/{{cookiecutter.project_slug}}/CLAUDE.md
+++ b/template/{{cookiecutter.project_slug}}/CLAUDE.md
@@ -12,6 +12,7 @@
 {%- if cookiecutter.enable_redis %}, Redis{%- endif %}
 {%- if cookiecutter.enable_ai_agent and cookiecutter.use_pydantic_ai %}, PydanticAI{%- endif %}
 {%- if cookiecutter.enable_ai_agent and cookiecutter.use_langchain %}, LangChain{%- endif %}
+{%- if cookiecutter.enable_ai_agent and cookiecutter.use_langgraph %}, LangGraph{%- endif %}
 {%- if cookiecutter.use_celery %}, Celery{%- endif %}
 {%- if cookiecutter.use_taskiq %}, Taskiq{%- endif %}
 {%- if cookiecutter.use_frontend %}, Next.js 15{%- endif %}

--- a/template/{{cookiecutter.project_slug}}/backend/app/agents/__init__.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/agents/__init__.py
@@ -18,6 +18,16 @@ Tools are defined in the tools/ subdirectory.
 from app.agents.langchain_assistant import AgentContext, AgentState, LangChainAssistant
 
 __all__ = ["LangChainAssistant", "AgentContext", "AgentState"]
+{%- elif cookiecutter.enable_ai_agent and cookiecutter.use_langgraph %}
+"""AI Agents module using LangGraph.
+
+This module contains a ReAct agent built with LangGraph.
+Tools are defined in the tools/ subdirectory.
+"""
+
+from app.agents.langgraph_assistant import AgentContext, AgentState, LangGraphAssistant
+
+__all__ = ["LangGraphAssistant", "AgentContext", "AgentState"]
 {%- else %}
 """AI Agents - not configured."""
 {%- endif %}

--- a/template/{{cookiecutter.project_slug}}/backend/app/agents/langgraph_assistant.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/agents/langgraph_assistant.py
@@ -1,0 +1,371 @@
+{%- if cookiecutter.enable_ai_agent and cookiecutter.use_langgraph %}
+"""LangGraph ReAct Agent implementation.
+
+A simple ReAct (Reasoning + Acting) agent built with LangGraph.
+Uses a graph-based architecture with conditional edges for tool execution.
+"""
+
+import logging
+from typing import Annotated, Any, Literal, TypedDict
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+{%- if cookiecutter.use_openai %}
+from langchain_openai import ChatOpenAI
+{%- endif %}
+{%- if cookiecutter.use_anthropic %}
+from langchain_anthropic import ChatAnthropic
+{%- endif %}
+
+from app.agents.prompts import DEFAULT_SYSTEM_PROMPT
+from app.agents.tools import get_current_datetime
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class AgentContext(TypedDict, total=False):
+    """Runtime context for the agent.
+
+    Passed via config parameter to the graph.
+    """
+
+    user_id: str | None
+    user_name: str | None
+    metadata: dict[str, Any]
+
+
+class AgentState(TypedDict):
+    """State for the LangGraph agent.
+
+    This is what flows through the agent graph.
+    The messages field uses add_messages reducer to properly
+    append new messages to the conversation history.
+    """
+
+    messages: Annotated[list[BaseMessage], add_messages]
+
+
+@tool
+def current_datetime() -> str:
+    """Get the current date and time.
+
+    Use this tool when you need to know the current date or time.
+    """
+    return get_current_datetime()
+
+
+# List of all available tools
+ALL_TOOLS = [current_datetime]
+
+# Create a dictionary for quick tool lookup by name
+TOOLS_BY_NAME = {t.name: t for t in ALL_TOOLS}
+
+
+class LangGraphAssistant:
+    """ReAct agent wrapper using LangGraph.
+
+    Implements a graph-based agent with:
+    - An agent node that processes messages and decides actions
+    - A tools node that executes tool calls
+    - Conditional edges that loop back for tool execution or end
+
+    The ReAct pattern:
+    1. Agent receives input and reasons about it
+    2. If tool calls are needed, execute them
+    3. Tool results are added to messages
+    4. Agent reasons again with new information
+    5. Repeat until agent provides final response
+    """
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        temperature: float | None = None,
+        system_prompt: str | None = None,
+    ):
+        self.model_name = model_name or settings.AI_MODEL
+        self.temperature = temperature or settings.AI_TEMPERATURE
+        self.system_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
+        self._graph = None
+        self._checkpointer = MemorySaver()
+
+    def _create_model(self):
+        """Create the LLM model with tools bound."""
+{%- if cookiecutter.use_openai %}
+        model = ChatOpenAI(
+            model=self.model_name,
+            temperature=self.temperature,
+            api_key=settings.OPENAI_API_KEY,
+            streaming=True,
+        )
+{%- endif %}
+{%- if cookiecutter.use_anthropic %}
+        model = ChatAnthropic(
+            model=self.model_name,
+            temperature=self.temperature,
+            api_key=settings.ANTHROPIC_API_KEY,
+            streaming=True,
+        )
+{%- endif %}
+
+        return model.bind_tools(ALL_TOOLS)
+
+    def _agent_node(self, state: AgentState) -> dict[str, list[BaseMessage]]:
+        """Agent node that processes messages and decides whether to call tools.
+
+        This is the main reasoning node in the ReAct pattern.
+        """
+        model = self._create_model()
+
+        # Prepend system message to the conversation
+        messages = [SystemMessage(content=self.system_prompt), *state["messages"]]
+
+        response = model.invoke(messages)
+
+        logger.info(
+            f"Agent processed message - Tool calls: {len(response.tool_calls) if hasattr(response, 'tool_calls') else 0}"
+        )
+
+        return {"messages": [response]}
+
+    def _tools_node(self, state: AgentState) -> dict[str, list[ToolMessage]]:
+        """Tools node that executes tool calls from the agent.
+
+        Processes each tool call and returns results as ToolMessages.
+        """
+        messages = state["messages"]
+        last_message = messages[-1]
+
+        tool_results = []
+
+        if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+            for tool_call in last_message.tool_calls:
+                tool_name = tool_call["name"]
+                tool_args = tool_call["args"]
+                tool_id = tool_call["id"]
+
+                logger.info(f"Executing tool: {tool_name} with args: {tool_args}")
+
+                try:
+                    tool_fn = TOOLS_BY_NAME.get(tool_name)
+                    if tool_fn:
+                        result = tool_fn.invoke(tool_args)
+                        tool_results.append(
+                            ToolMessage(
+                                content=str(result),
+                                tool_call_id=tool_id,
+                                name=tool_name,
+                            )
+                        )
+                        logger.info(f"Tool {tool_name} completed successfully")
+                    else:
+                        error_msg = f"Unknown tool: {tool_name}"
+                        logger.error(error_msg)
+                        tool_results.append(
+                            ToolMessage(
+                                content=error_msg,
+                                tool_call_id=tool_id,
+                                name=tool_name,
+                            )
+                        )
+                except Exception as e:
+                    error_msg = f"Error executing {tool_name}: {str(e)}"
+                    logger.error(error_msg, exc_info=True)
+                    tool_results.append(
+                        ToolMessage(
+                            content=error_msg,
+                            tool_call_id=tool_id,
+                            name=tool_name,
+                        )
+                    )
+
+        return {"messages": tool_results}
+
+    def _should_continue(self, state: AgentState) -> Literal["tools", "__end__"]:
+        """Conditional edge that decides whether to continue to tools or end.
+
+        Returns:
+            - "tools" if the agent made tool calls (needs to execute tools)
+            - "__end__" if the agent provided a final response (no tool calls)
+        """
+        messages = state["messages"]
+        last_message = messages[-1]
+
+        if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+            logger.info(f"Continuing to tools - {len(last_message.tool_calls)} tool(s) to execute")
+            return "tools"
+
+        logger.info("No tool calls - ending conversation")
+        return "__end__"
+
+    def _build_graph(self) -> StateGraph:
+        """Build and compile the LangGraph state graph."""
+        workflow = StateGraph(AgentState)
+
+        # Add nodes
+        workflow.add_node("agent", self._agent_node)
+        workflow.add_node("tools", self._tools_node)
+
+        # Add edges
+        workflow.add_edge(START, "agent")
+        workflow.add_conditional_edges(
+            "agent",
+            self._should_continue,
+            {"tools": "tools", "__end__": END},
+        )
+        workflow.add_edge("tools", "agent")
+
+        return workflow.compile(checkpointer=self._checkpointer)
+
+    @property
+    def graph(self):
+        """Get or create the compiled graph instance."""
+        if self._graph is None:
+            self._graph = self._build_graph()
+        return self._graph
+
+    @staticmethod
+    def _convert_history(
+        history: list[dict[str, str]] | None,
+    ) -> list[HumanMessage | AIMessage | SystemMessage]:
+        """Convert conversation history to LangChain message format."""
+        messages: list[HumanMessage | AIMessage | SystemMessage] = []
+
+        for msg in history or []:
+            if msg["role"] == "user":
+                messages.append(HumanMessage(content=msg["content"]))
+            elif msg["role"] == "assistant":
+                messages.append(AIMessage(content=msg["content"]))
+            elif msg["role"] == "system":
+                messages.append(SystemMessage(content=msg["content"]))
+
+        return messages
+
+    async def run(
+        self,
+        user_input: str,
+        history: list[dict[str, str]] | None = None,
+        context: AgentContext | None = None,
+        thread_id: str = "default",
+    ) -> tuple[str, list[Any], AgentContext]:
+        """Run agent and return the output along with tool call events.
+
+        Args:
+            user_input: User's message.
+            history: Conversation history as list of {"role": "...", "content": "..."}.
+            context: Optional runtime context with user info.
+            thread_id: Thread ID for conversation continuity.
+
+        Returns:
+            Tuple of (output_text, tool_events, context).
+        """
+        messages = self._convert_history(history)
+        messages.append(HumanMessage(content=user_input))
+
+        agent_context: AgentContext = context if context is not None else {}
+
+        logger.info(f"Running agent with user input: {user_input[:100]}...")
+
+        config = {
+            "configurable": {
+                "thread_id": thread_id,
+                **agent_context,
+            }
+        }
+
+        result = await self.graph.ainvoke({"messages": messages}, config=config)
+
+        # Extract the final response and tool events
+        output = ""
+        tool_events: list[Any] = []
+
+        for message in result.get("messages", []):
+            if isinstance(message, AIMessage):
+                if message.content:
+                    output = message.content if isinstance(message.content, str) else str(message.content)
+                if hasattr(message, "tool_calls") and message.tool_calls:
+                    tool_events.extend(message.tool_calls)
+
+        logger.info(f"Agent run complete. Output length: {len(output)} chars")
+
+        return output, tool_events, agent_context
+
+    async def stream(
+        self,
+        user_input: str,
+        history: list[dict[str, str]] | None = None,
+        context: AgentContext | None = None,
+        thread_id: str = "default",
+    ):
+        """Stream agent execution with message and state update streaming.
+
+        Args:
+            user_input: User's message.
+            history: Conversation history.
+            context: Optional runtime context.
+            thread_id: Thread ID for conversation continuity.
+
+        Yields:
+            Tuples of (stream_mode, data) for streaming responses.
+            - stream_mode="messages": (chunk, metadata) for LLM tokens
+            - stream_mode="updates": state updates after each node
+        """
+        messages = self._convert_history(history)
+        messages.append(HumanMessage(content=user_input))
+
+        agent_context: AgentContext = context if context is not None else {}
+
+        config = {
+            "configurable": {
+                "thread_id": thread_id,
+                **agent_context,
+            }
+        }
+
+        logger.info(f"Starting stream for user input: {user_input[:100]}...")
+
+        async for stream_mode, data in self.graph.astream(
+            {"messages": messages},
+            config=config,
+            stream_mode=["messages", "updates"],
+        ):
+            yield stream_mode, data
+
+
+def get_agent() -> LangGraphAssistant:
+    """Factory function to create a LangGraphAssistant.
+
+    Returns:
+        Configured LangGraphAssistant instance.
+    """
+    return LangGraphAssistant()
+
+
+async def run_agent(
+    user_input: str,
+    history: list[dict[str, str]],
+    context: AgentContext | None = None,
+    thread_id: str = "default",
+) -> tuple[str, list[Any], AgentContext]:
+    """Run agent and return the output along with tool call events.
+
+    This is a convenience function for backwards compatibility.
+
+    Args:
+        user_input: User's message.
+        history: Conversation history.
+        context: Optional runtime context.
+        thread_id: Thread ID for conversation continuity.
+
+    Returns:
+        Tuple of (output_text, tool_events, context).
+    """
+    agent = get_agent()
+    return await agent.run(user_input, history, context, thread_id)
+{%- else %}
+"""LangGraph Assistant agent - not configured."""
+{%- endif %}

--- a/template/{{cookiecutter.project_slug}}/backend/app/api/routes/v1/agent.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/api/routes/v1/agent.py
@@ -897,6 +897,448 @@ async def agent_websocket(
         pass  # Normal disconnect
     finally:
         manager.disconnect(websocket)
+{%- elif cookiecutter.enable_ai_agent and cookiecutter.use_langgraph %}
+"""AI Agent WebSocket routes with streaming support (LangGraph ReAct Agent)."""
+
+import logging
+from typing import Any
+{%- if cookiecutter.enable_conversation_persistence and cookiecutter.use_database %}
+from datetime import datetime, UTC
+{%- if cookiecutter.use_postgresql %}
+from uuid import UUID
+{%- endif %}
+{%- endif %}
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect{%- if cookiecutter.websocket_auth_jwt %}, Depends{%- endif %}{%- if cookiecutter.websocket_auth_api_key %}, Query{%- endif %}
+
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, SystemMessage, ToolMessage
+
+from app.agents.langgraph_assistant import AgentContext, get_agent
+{%- if cookiecutter.websocket_auth_jwt %}
+from app.api.deps import get_current_user_ws
+from app.db.models.user import User
+{%- endif %}
+{%- if cookiecutter.websocket_auth_api_key %}
+from app.core.config import settings
+{%- endif %}
+{%- if cookiecutter.enable_conversation_persistence and (cookiecutter.use_postgresql or cookiecutter.use_sqlite) %}
+from app.db.session import get_db_context
+from app.api.deps import ConversationSvc, get_conversation_service
+from app.schemas.conversation import ConversationCreate, MessageCreate, ToolCallCreate, ToolCallComplete
+{%- elif cookiecutter.enable_conversation_persistence and cookiecutter.use_mongodb %}
+from app.api.deps import ConversationSvc, get_conversation_service
+from app.schemas.conversation import ConversationCreate, MessageCreate, ToolCallCreate, ToolCallComplete
+{%- endif %}
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class AgentConnectionManager:
+    """WebSocket connection manager for AI agent."""
+
+    def __init__(self) -> None:
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """Accept and store a new WebSocket connection."""
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info(f"Agent WebSocket connected. Total connections: {len(self.active_connections)}")
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """Remove a WebSocket connection."""
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+        logger.info(f"Agent WebSocket disconnected. Total connections: {len(self.active_connections)}")
+
+    async def send_event(self, websocket: WebSocket, event_type: str, data: Any) -> bool:
+        """Send a JSON event to a specific WebSocket client.
+
+        Returns True if sent successfully, False if connection is closed.
+        """
+        try:
+            await websocket.send_json({"type": event_type, "data": data})
+            return True
+        except (WebSocketDisconnect, RuntimeError):
+            # Connection already closed
+            return False
+
+
+manager = AgentConnectionManager()
+
+
+def build_message_history(
+    history: list[dict[str, str]]
+) -> list[HumanMessage | AIMessage | SystemMessage]:
+    """Convert conversation history to LangChain message format."""
+    messages: list[HumanMessage | AIMessage | SystemMessage] = []
+
+    for msg in history:
+        if msg["role"] == "user":
+            messages.append(HumanMessage(content=msg["content"]))
+        elif msg["role"] == "assistant":
+            messages.append(AIMessage(content=msg["content"]))
+        elif msg["role"] == "system":
+            messages.append(SystemMessage(content=msg["content"]))
+
+    return messages
+
+{%- if cookiecutter.websocket_auth_api_key %}
+
+
+async def verify_api_key(api_key: str) -> bool:
+    """Verify the API key for WebSocket authentication."""
+    return api_key == settings.API_KEY
+{%- endif %}
+
+
+@router.websocket("/ws/agent")
+async def agent_websocket(
+    websocket: WebSocket,
+{%- if cookiecutter.websocket_auth_jwt %}
+    user: User = Depends(get_current_user_ws),
+{%- elif cookiecutter.websocket_auth_api_key %}
+    api_key: str = Query(..., alias="api_key"),
+{%- endif %}
+) -> None:
+    """WebSocket endpoint for LangGraph ReAct agent with streaming support.
+
+    Uses LangGraph astream_events() to stream all agent events including:
+    - user_prompt: When user input is received
+    - model_request_start: When model request begins
+    - text_delta: Streaming text from the model
+    - tool_call: When a tool is called
+    - tool_result: When a tool returns a result
+    - final_result: When the final result is ready
+    - complete: When processing is complete
+    - error: When an error occurs
+
+    Expected input message format:
+    {
+        "message": "user message here",
+        "history": [{"role": "user|assistant|system", "content": "..."}]{% if cookiecutter.enable_conversation_persistence and cookiecutter.use_database %},
+        "conversation_id": "optional-uuid-to-continue-existing-conversation"{% endif %}
+    }
+{%- if cookiecutter.websocket_auth_jwt %}
+
+    Authentication: Requires a valid JWT token passed as a query parameter or header.
+{%- elif cookiecutter.websocket_auth_api_key %}
+
+    Authentication: Requires a valid API key passed as 'api_key' query parameter.
+    Example: ws://localhost:{{ cookiecutter.backend_port }}/api/v1/ws/agent?api_key=your-api-key
+{%- endif %}
+{%- if cookiecutter.enable_conversation_persistence and cookiecutter.use_database %}
+
+    Persistence: Set 'conversation_id' to continue an existing conversation.
+    If not provided, a new conversation is created. The conversation_id is
+    returned in the 'conversation_created' event.
+{%- endif %}
+    """
+{%- if cookiecutter.websocket_auth_api_key %}
+    # Verify API key before accepting connection
+    if not await verify_api_key(api_key):
+        await websocket.close(code=4001, reason="Invalid API key")
+        return
+{%- endif %}
+
+    await manager.connect(websocket)
+
+    # Conversation state per connection
+    conversation_history: list[dict[str, str]] = []
+    context: AgentContext = {}
+{%- if cookiecutter.websocket_auth_jwt %}
+    context["user_id"] = str(user.id) if user else None
+    context["user_name"] = user.email if user else None
+{%- endif %}
+{%- if cookiecutter.enable_conversation_persistence and cookiecutter.use_database %}
+    current_conversation_id: str | None = None
+{%- endif %}
+
+    try:
+        while True:
+            # Receive user message
+            data = await websocket.receive_json()
+            user_message = data.get("message", "")
+            # Optionally accept history from client (or use server-side tracking)
+            if "history" in data:
+                conversation_history = data["history"]
+
+            if not user_message:
+                await manager.send_event(websocket, "error", {"message": "Empty message"})
+                continue
+
+{%- if cookiecutter.enable_conversation_persistence and (cookiecutter.use_postgresql or cookiecutter.use_sqlite) %}
+
+            # Handle conversation persistence
+            try:
+{%- if cookiecutter.use_postgresql %}
+                async with get_db_context() as db:
+                    conv_service = get_conversation_service(db)
+
+                    # Get or create conversation
+                    requested_conv_id = data.get("conversation_id")
+                    if requested_conv_id:
+                        current_conversation_id = requested_conv_id
+                        # Verify conversation exists
+                        await conv_service.get_conversation(UUID(requested_conv_id))
+                    elif not current_conversation_id:
+                        # Create new conversation
+                        conv_data = ConversationCreate(
+{%- if cookiecutter.websocket_auth_jwt %}
+                            user_id=user.id,
+{%- endif %}
+                            title=user_message[:50] if len(user_message) > 50 else user_message,
+                        )
+                        conversation = await conv_service.create_conversation(conv_data)
+                        current_conversation_id = str(conversation.id)
+                        await manager.send_event(
+                            websocket,
+                            "conversation_created",
+                            {"conversation_id": current_conversation_id},
+                        )
+
+                    # Save user message
+                    await conv_service.add_message(
+                        UUID(current_conversation_id),
+                        MessageCreate(role="user", content=user_message),
+                    )
+{%- else %}
+                with get_db_session() as db:
+                    conv_service = get_conversation_service(db)
+
+                    # Get or create conversation
+                    requested_conv_id = data.get("conversation_id")
+                    if requested_conv_id:
+                        current_conversation_id = requested_conv_id
+                        conv_service.get_conversation(requested_conv_id)
+                    elif not current_conversation_id:
+                        # Create new conversation
+                        conv_data = ConversationCreate(
+{%- if cookiecutter.websocket_auth_jwt %}
+                            user_id=str(user.id),
+{%- endif %}
+                            title=user_message[:50] if len(user_message) > 50 else user_message,
+                        )
+                        conversation = conv_service.create_conversation(conv_data)
+                        current_conversation_id = str(conversation.id)
+                        await manager.send_event(
+                            websocket,
+                            "conversation_created",
+                            {"conversation_id": current_conversation_id},
+                        )
+
+                    # Save user message
+                    conv_service.add_message(
+                        current_conversation_id,
+                        MessageCreate(role="user", content=user_message),
+                    )
+{%- endif %}
+            except Exception as e:
+                logger.warning(f"Failed to persist conversation: {e}")
+                # Continue without persistence
+{%- elif cookiecutter.enable_conversation_persistence and cookiecutter.use_mongodb %}
+
+            # Handle conversation persistence (MongoDB)
+            conv_service = get_conversation_service()
+
+            requested_conv_id = data.get("conversation_id")
+            if requested_conv_id:
+                current_conversation_id = requested_conv_id
+                await conv_service.get_conversation(requested_conv_id)
+            elif not current_conversation_id:
+                conv_data = ConversationCreate(
+{%- if cookiecutter.websocket_auth_jwt %}
+                    user_id=str(user.id),
+{%- endif %}
+                    title=user_message[:50] if len(user_message) > 50 else user_message,
+                )
+                conversation = await conv_service.create_conversation(conv_data)
+                current_conversation_id = str(conversation.id)
+                await manager.send_event(
+                    websocket,
+                    "conversation_created",
+                    {"conversation_id": current_conversation_id},
+                )
+
+            # Save user message
+            await conv_service.add_message(
+                current_conversation_id,
+                MessageCreate(role="user", content=user_message),
+            )
+{%- endif %}
+
+            await manager.send_event(websocket, "user_prompt", {"content": user_message})
+
+            try:
+                assistant = get_agent()
+
+                final_output = ""
+                tool_events: list[Any] = []
+                seen_tool_call_ids: set[str] = set()
+
+                await manager.send_event(websocket, "model_request_start", {})
+
+                # Use LangGraph's astream with messages and updates modes
+                async for stream_mode, data in assistant.stream(
+                    user_message,
+                    history=conversation_history,
+                    context=context,
+                ):
+                    if stream_mode == "messages":
+                        chunk, _metadata = data
+
+                        if isinstance(chunk, AIMessageChunk):
+                            if chunk.content:
+                                text_content = ""
+                                if isinstance(chunk.content, str):
+                                    text_content = chunk.content
+                                elif isinstance(chunk.content, list):
+                                    for block in chunk.content:
+                                        if isinstance(block, dict) and block.get("type") == "text":
+                                            text_content += block.get("text", "")
+                                        elif isinstance(block, str):
+                                            text_content += block
+
+                                if text_content:
+                                    await manager.send_event(
+                                        websocket,
+                                        "text_delta",
+                                        {"content": text_content},
+                                    )
+                                    final_output += text_content
+
+                            # Handle tool call chunks
+                            if chunk.tool_call_chunks:
+                                for tc_chunk in chunk.tool_call_chunks:
+                                    tc_id = tc_chunk.get("id")
+                                    tc_name = tc_chunk.get("name")
+                                    if tc_id and tc_name and tc_id not in seen_tool_call_ids:
+                                        seen_tool_call_ids.add(tc_id)
+                                        await manager.send_event(
+                                            websocket,
+                                            "tool_call",
+                                            {
+                                                "tool_name": tc_name,
+                                                "args": {},
+                                                "tool_call_id": tc_id,
+                                            },
+                                        )
+
+                    elif stream_mode == "updates":
+                        # Handle state updates from nodes
+                        for node_name, update in data.items():
+                            if node_name == "tools":
+                                # Tool node completed - extract tool results
+                                for msg in update.get("messages", []):
+                                    if isinstance(msg, ToolMessage):
+                                        await manager.send_event(
+                                            websocket,
+                                            "tool_result",
+                                            {
+                                                "tool_call_id": msg.tool_call_id,
+                                                "content": msg.content,
+                                            },
+                                        )
+                            elif node_name == "agent":
+                                # Agent node completed - check for tool calls
+                                for msg in update.get("messages", []):
+                                    if isinstance(msg, AIMessage) and msg.tool_calls:
+                                        for tc in msg.tool_calls:
+                                            tc_id = tc.get("id", "")
+                                            if tc_id not in seen_tool_call_ids:
+                                                seen_tool_call_ids.add(tc_id)
+                                                tool_events.append(tc)
+                                                await manager.send_event(
+                                                    websocket,
+                                                    "tool_call",
+                                                    {
+                                                        "tool_name": tc.get("name", ""),
+                                                        "args": tc.get("args", {}),
+                                                        "tool_call_id": tc_id,
+                                                    },
+                                                )
+
+                await manager.send_event(
+                    websocket,
+                    "final_result",
+                    {"output": final_output},
+                )
+
+                # Update conversation history
+                conversation_history.append({"role": "user", "content": user_message})
+                if final_output:
+                    conversation_history.append(
+                        {"role": "assistant", "content": final_output}
+                    )
+
+{%- if cookiecutter.enable_conversation_persistence and (cookiecutter.use_postgresql or cookiecutter.use_sqlite) %}
+
+                # Save assistant response to database
+                if current_conversation_id and final_output:
+                    try:
+{%- if cookiecutter.use_postgresql %}
+                        async with get_db_context() as db:
+                            conv_service = get_conversation_service(db)
+                            await conv_service.add_message(
+                                UUID(current_conversation_id),
+                                MessageCreate(
+                                    role="assistant",
+                                    content=final_output,
+                                    model_name=assistant.model_name if hasattr(assistant, "model_name") else None,
+                                ),
+                            )
+{%- else %}
+                        with get_db_session() as db:
+                            conv_service = get_conversation_service(db)
+                            conv_service.add_message(
+                                current_conversation_id,
+                                MessageCreate(
+                                    role="assistant",
+                                    content=final_output,
+                                    model_name=assistant.model_name if hasattr(assistant, "model_name") else None,
+                                ),
+                            )
+{%- endif %}
+                    except Exception as e:
+                        logger.warning(f"Failed to persist assistant response: {e}")
+{%- elif cookiecutter.enable_conversation_persistence and cookiecutter.use_mongodb %}
+
+                # Save assistant response to database
+                if current_conversation_id and final_output:
+                    try:
+                        await conv_service.add_message(
+                            current_conversation_id,
+                            MessageCreate(
+                                role="assistant",
+                                content=final_output,
+                                model_name=assistant.model_name if hasattr(assistant, "model_name") else None,
+                            ),
+                        )
+                    except Exception as e:
+                        logger.warning(f"Failed to persist assistant response: {e}")
+{%- endif %}
+
+                await manager.send_event(websocket, "complete", {
+{%- if cookiecutter.enable_conversation_persistence and cookiecutter.use_database %}
+                    "conversation_id": current_conversation_id,
+{%- endif %}
+                })
+
+            except WebSocketDisconnect:
+                # Client disconnected during processing - this is normal
+                logger.info("Client disconnected during agent processing")
+                break
+            except Exception as e:
+                logger.exception(f"Error processing agent request: {e}")
+                # Try to send error, but don't fail if connection is closed
+                await manager.send_event(websocket, "error", {"message": str(e)})
+
+    except WebSocketDisconnect:
+        pass  # Normal disconnect
+    finally:
+        manager.disconnect(websocket)
 {%- else %}
 """AI Agent routes - not configured."""
 {%- endif %}

--- a/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
+++ b/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
@@ -122,6 +122,17 @@ dependencies = [
 {%- endif %}
     "langgraph>=0.2.0",
 {%- endif %}
+{%- if cookiecutter.enable_ai_agent and cookiecutter.use_langgraph %}
+    "langchain-core>=0.3.0",
+{%- if cookiecutter.use_openai %}
+    "langchain-openai>=0.3.0",
+{%- endif %}
+{%- if cookiecutter.use_anthropic %}
+    "langchain-anthropic>=0.3.0",
+{%- endif %}
+    "langgraph>=0.2.0",
+    "langgraph-checkpoint>=2.0.0",
+{%- endif %}
 {%- if cookiecutter.logfire_httpx or cookiecutter.enable_file_storage %}
     "httpx>=0.27.0",
 {%- endif %}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -634,6 +634,17 @@ class TestOptionCombinationValidation:
             )
         assert "OpenRouter is not supported with LangChain" in str(exc_info.value)
 
+    def test_openrouter_with_langgraph_raises_validation_error(self) -> None:
+        """Test that OpenRouter + LangGraph combination is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ProjectConfig(
+                project_name="test",
+                enable_ai_agent=True,
+                llm_provider=LLMProviderType.OPENROUTER,
+                ai_framework=AIFrameworkType.LANGGRAPH,
+            )
+        assert "OpenRouter is not supported with LangGraph" in str(exc_info.value)
+
     def test_openrouter_with_pydanticai_is_valid(self) -> None:
         """Test that OpenRouter + PydanticAI combination is accepted."""
         config = ProjectConfig(

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-fullstack"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## [0.1.11] - 2026-01-02

### Added

#### LangGraph ReAct Agent Support

- **LangGraph as third AI framework option** alongside PydanticAI and LangChain
- New `--ai-framework langgraph` CLI option for project creation
- Interactive prompt includes "LangGraph (ReAct agent)" choice
- **ReAct (Reasoning + Acting) agent pattern** with graph-based architecture:
  - Agent node for LLM reasoning and tool decision
  - Tools node for executing tool calls
  - Conditional edges for tool execution loop
  - Memory-based checkpointing for conversation continuity
- **Full WebSocket streaming support** using `astream()` with dual modes:
  - `messages` mode for token-level LLM streaming
  - `updates` mode for node state changes (tool calls/results)
- **Tool result correlation** - proper `tool_call_id` matching between calls and results
- New template files:
  - `app/agents/langgraph_assistant.py` - LangGraphAssistant class with run() and stream()
  - WebSocket route implementation in `app/api/routes/v1/agent.py`
- New cookiecutter variable: `use_langgraph`
- Dependencies for LangGraph projects:
  - `langchain-core>=0.3.0`
  - `langchain-openai>=0.3.0` or `langchain-anthropic>=0.3.0`
  - `langgraph>=0.2.0`
  - `langgraph-checkpoint>=2.0.0`

### Changed

- **`AIFrameworkType` enum** extended with `LANGGRAPH` value
- **AI framework prompt** now shows three options: PydanticAI, LangChain, LangGraph
- **LLM provider validation** - OpenRouter not supported with LangGraph (same as LangChain)
- **`VARIABLES.md`** updated with `use_langgraph` documentation
- **Template `CLAUDE.md`** includes LangGraph in stack section
