### PR TITLE
fix: add SSRF protection for webhook URLs (CWE-918)

### DIFF
--- a/template/{{cookiecutter.project_slug}}/backend/app/core/sanitize.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/core/sanitize.py
@@ -36,6 +36,14 @@ DEFAULT_ALLOWED_ATTRIBUTES = {
 WEBHOOK_ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 
+class SSRFBlockedError(ValueError):
+    """Raised when a URL is blocked by SSRF protection.
+
+    Dedicated exception type to avoid fragile string matching when
+    distinguishing SSRF blocks from other ValueErrors.
+    """
+
+
 def sanitize_html(
     content: str,
     allowed_tags: frozenset[str] | None = None,
@@ -190,6 +198,7 @@ def validate_webhook_url(
 
     Checks that the URL:
     - Uses an allowed scheme (http/https only by default)
+    - Does not contain userinfo (credentials in the URL)
     - Does not point to private, reserved, loopback, or link-local IP addresses
     - Resolves via DNS to a public IP (prevents DNS rebinding attacks)
 
@@ -201,13 +210,14 @@ def validate_webhook_url(
         The validated URL string.
 
     Raises:
-        ValueError: If the URL is not safe for outbound requests.
+        SSRFBlockedError: If the URL is blocked by SSRF protection.
+        ValueError: If the URL is malformed.
 
     Example:
         >>> validate_webhook_url("https://example.com/webhook")
         "https://example.com/webhook"
         >>> validate_webhook_url("http://169.254.169.254/latest/meta-data/")
-        Raises ValueError
+        Raises SSRFBlockedError
     """
     if allowed_schemes is None:
         allowed_schemes = WEBHOOK_ALLOWED_SCHEMES
@@ -220,7 +230,7 @@ def validate_webhook_url(
 
     # Validate scheme
     if parsed.scheme not in allowed_schemes:
-        raise ValueError(
+        raise SSRFBlockedError(
             f"URL scheme {parsed.scheme!r} is not allowed. "
             f"Allowed schemes: {', '.join(sorted(allowed_schemes))}"
         )
@@ -230,37 +240,50 @@ def validate_webhook_url(
     if not hostname:
         raise ValueError(f"Invalid webhook URL: no hostname found in {url!r}")
 
+    # Reject URLs with userinfo (credentials) to prevent URL parsing ambiguities
+    # e.g. http://user:pass@host/ or http://foo@169.254.169.254%00@public.com/
+    if parsed.username is not None or parsed.password is not None:
+        raise SSRFBlockedError(
+            "Webhook URL must not contain credentials (userinfo). "
+            "Remove the user:password@ portion from the URL."
+        )
+
     # Try to parse hostname directly as an IP address
     try:
         addr = ipaddress.ip_address(hostname)
         if _is_ip_blocked(str(addr)):
-            raise ValueError(
+            raise SSRFBlockedError(
                 f"Webhook URL blocked: {hostname!r} resolves to a private/internal "
                 f"address. SSRF protection does not allow requests to internal networks."
             )
         return url
-    except ValueError as err:
-        if "SSRF" in str(err) or "blocked" in str(err):
-            raise
+    except SSRFBlockedError:
+        raise
+    except ValueError:
         # Not an IP literal — continue to DNS resolution below
+        pass
+
+    # Determine the correct default port based on the scheme
+    default_port = 443 if parsed.scheme == "https" else 80
+    port = parsed.port or default_port
 
     # Resolve hostname via DNS and check all returned addresses
     try:
-        addr_infos = socket.getaddrinfo(hostname, parsed.port or 443, proto=socket.IPPROTO_TCP)
+        addr_infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror as err:
-        raise ValueError(
+        raise SSRFBlockedError(
             f"Webhook URL blocked: unable to resolve hostname {hostname!r}"
         ) from err
 
     if not addr_infos:
-        raise ValueError(
+        raise SSRFBlockedError(
             f"Webhook URL blocked: hostname {hostname!r} did not resolve to any address"
         )
 
     for family, _type, _proto, _canonname, sockaddr in addr_infos:
         ip_str = sockaddr[0]
         if _is_ip_blocked(ip_str):
-            raise ValueError(
+            raise SSRFBlockedError(
                 f"Webhook URL blocked: {hostname!r} resolves to private/internal "
                 f"address {ip_str!r}. SSRF protection does not allow requests to "
                 f"internal networks."

--- a/template/{{cookiecutter.project_slug}}/backend/app/core/sanitize.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/core/sanitize.py
@@ -35,6 +35,12 @@ DEFAULT_ALLOWED_ATTRIBUTES = {
 # Allowed URL schemes for webhook URLs
 WEBHOOK_ALLOWED_SCHEMES = frozenset({"http", "https"})
 
+# Shared Address Space (RFC 6598) — CGNAT range.
+# Python 3.11+ no longer classifies 100.64.0.0/10 as private or reserved,
+# so we block it explicitly. Covers cloud metadata endpoints like
+# Alibaba Cloud's 100.100.100.200.
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
 
 class SSRFBlockedError(ValueError):
     """Raised when a URL is blocked by SSRF protection.
@@ -187,6 +193,7 @@ def _is_ip_blocked(ip_str: str) -> bool:
         or addr.is_link_local
         or addr.is_multicast
         or addr.is_unspecified
+        or addr in _CGNAT_NETWORK
     )
 
 
@@ -268,6 +275,8 @@ def validate_webhook_url(
     port = parsed.port or default_port
 
     # Resolve hostname via DNS and check all returned addresses
+    # TODO: socket.getaddrinfo() is blocking I/O — in async code paths
+    # (PostgreSQL, MongoDB) consider using loop.getaddrinfo() or run_in_executor.
     try:
         addr_infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror as err:
@@ -280,7 +289,7 @@ def validate_webhook_url(
             f"Webhook URL blocked: hostname {hostname!r} did not resolve to any address"
         )
 
-    for family, _type, _proto, _canonname, sockaddr in addr_infos:
+    for _family, _type, _proto, _canonname, sockaddr in addr_infos:
         ip_str = sockaddr[0]
         if _is_ip_blocked(ip_str):
             raise SSRFBlockedError(

--- a/template/{{cookiecutter.project_slug}}/backend/app/core/sanitize.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/core/sanitize.py
@@ -3,17 +3,21 @@
 This module provides security-focused input sanitization functions:
 - HTML sanitization to prevent XSS attacks
 - Path traversal prevention for file operations
+- Webhook URL validation to prevent SSRF attacks
 - Common input cleaning utilities
 
 Note: SQL injection is prevented by using SQLAlchemy ORM with parameterized queries.
 """
 
 import html
+import ipaddress
 import os
 import re
+import socket
 import unicodedata
 from pathlib import Path
 from typing import TypeVar
+from urllib.parse import urlparse
 
 # Default allowed HTML tags for rich text content
 DEFAULT_ALLOWED_TAGS = frozenset({
@@ -27,6 +31,9 @@ DEFAULT_ALLOWED_ATTRIBUTES = {
     "abbr": frozenset({"title"}),
     "acronym": frozenset({"title"}),
 }
+
+# Allowed URL schemes for webhook URLs
+WEBHOOK_ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 
 def sanitize_html(
@@ -148,6 +155,118 @@ def validate_safe_path(
         ) from err
 
     return full_path
+
+
+def _is_ip_blocked(ip_str: str) -> bool:
+    """Check if an IP address is private, reserved, loopback, or link-local.
+
+    Args:
+        ip_str: The IP address string to check.
+
+    Returns:
+        True if the address should be blocked, False if it's safe.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        # If we can't parse it, block it to be safe
+        return True
+
+    return (
+        addr.is_private
+        or addr.is_reserved
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def validate_webhook_url(
+    url: str,
+    allowed_schemes: frozenset[str] | None = None,
+) -> str:
+    """Validate a webhook URL to prevent SSRF attacks.
+
+    Checks that the URL:
+    - Uses an allowed scheme (http/https only by default)
+    - Does not point to private, reserved, loopback, or link-local IP addresses
+    - Resolves via DNS to a public IP (prevents DNS rebinding attacks)
+
+    Args:
+        url: The webhook URL to validate.
+        allowed_schemes: Allowed URL schemes. Defaults to {"http", "https"}.
+
+    Returns:
+        The validated URL string.
+
+    Raises:
+        ValueError: If the URL is not safe for outbound requests.
+
+    Example:
+        >>> validate_webhook_url("https://example.com/webhook")
+        "https://example.com/webhook"
+        >>> validate_webhook_url("http://169.254.169.254/latest/meta-data/")
+        Raises ValueError
+    """
+    if allowed_schemes is None:
+        allowed_schemes = WEBHOOK_ALLOWED_SCHEMES
+
+    # Parse the URL
+    try:
+        parsed = urlparse(url)
+    except Exception as err:
+        raise ValueError(f"Invalid webhook URL: {url!r}") from err
+
+    # Validate scheme
+    if parsed.scheme not in allowed_schemes:
+        raise ValueError(
+            f"URL scheme {parsed.scheme!r} is not allowed. "
+            f"Allowed schemes: {', '.join(sorted(allowed_schemes))}"
+        )
+
+    # Extract hostname
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"Invalid webhook URL: no hostname found in {url!r}")
+
+    # Try to parse hostname directly as an IP address
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if _is_ip_blocked(str(addr)):
+            raise ValueError(
+                f"Webhook URL blocked: {hostname!r} resolves to a private/internal "
+                f"address. SSRF protection does not allow requests to internal networks."
+            )
+        return url
+    except ValueError as err:
+        if "SSRF" in str(err) or "blocked" in str(err):
+            raise
+        # Not an IP literal — continue to DNS resolution below
+
+    # Resolve hostname via DNS and check all returned addresses
+    try:
+        addr_infos = socket.getaddrinfo(hostname, parsed.port or 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as err:
+        raise ValueError(
+            f"Webhook URL blocked: unable to resolve hostname {hostname!r}"
+        ) from err
+
+    if not addr_infos:
+        raise ValueError(
+            f"Webhook URL blocked: hostname {hostname!r} did not resolve to any address"
+        )
+
+    for family, _type, _proto, _canonname, sockaddr in addr_infos:
+        ip_str = sockaddr[0]
+        if _is_ip_blocked(ip_str):
+            raise ValueError(
+                f"Webhook URL blocked: {hostname!r} resolves to private/internal "
+                f"address {ip_str!r}. SSRF protection does not allow requests to "
+                f"internal networks."
+            )
+
+    return url
 
 
 def sanitize_string(

--- a/template/{{cookiecutter.project_slug}}/backend/app/services/webhook.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/services/webhook.py
@@ -13,13 +13,21 @@ from uuid import UUID
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.exceptions import NotFoundError
-from app.core.sanitize import validate_webhook_url
+from app.core.exceptions import NotFoundError, ValidationError
+from app.core.sanitize import SSRFBlockedError, validate_webhook_url
 from app.db.models.webhook import Webhook, WebhookDelivery
 from app.repositories import webhook_repo
 from app.schemas.webhook import WebhookCreate, WebhookUpdate
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_url_or_raise_422(url: str) -> str:
+    """Validate a webhook URL; convert SSRF/ValueError into ValidationError (422)."""
+    try:
+        return validate_webhook_url(url)
+    except (SSRFBlockedError, ValueError) as exc:
+        raise ValidationError(message=str(exc)) from exc
 
 
 class WebhookService:
@@ -35,7 +43,7 @@ class WebhookService:
     ) -> Webhook:
         """Create a new webhook subscription."""
         # Validate URL against SSRF before storing
-        validate_webhook_url(str(data.url))
+        _validate_url_or_raise_422(str(data.url))
 
         # Generate a secure secret for HMAC signing
         secret = secrets.token_urlsafe(32)
@@ -76,7 +84,7 @@ class WebhookService:
         """Update a webhook."""
         # Validate new URL against SSRF if provided
         if data.url is not None:
-            validate_webhook_url(str(data.url))
+            _validate_url_or_raise_422(str(data.url))
 
         webhook = await self.get_webhook(webhook_id)
         return await webhook_repo.update(self.db, webhook, data)
@@ -138,7 +146,7 @@ class WebhookService:
     ) -> dict:
         """Deliver a payload to a webhook with HMAC signature."""
         # Re-validate URL at delivery time to prevent DNS rebinding attacks
-        validate_webhook_url(webhook.url)
+        _validate_url_or_raise_422(webhook.url)
 
         payload_json = json.dumps(payload, default=str)
 
@@ -160,6 +168,9 @@ class WebhookService:
         await self.db.flush()
 
         try:
+            # SECURITY: follow_redirects defaults to False in httpx.
+            # Do NOT enable it — redirects could bypass SSRF validation
+            # by redirecting to an internal IP after the URL check passes.
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     webhook.url,
@@ -240,13 +251,21 @@ from datetime import UTC, datetime
 import httpx
 from sqlalchemy.orm import Session as DBSession
 
-from app.core.exceptions import NotFoundError
-from app.core.sanitize import validate_webhook_url
+from app.core.exceptions import NotFoundError, ValidationError
+from app.core.sanitize import SSRFBlockedError, validate_webhook_url
 from app.db.models.webhook import Webhook, WebhookDelivery
 from app.repositories import webhook_repo
 from app.schemas.webhook import WebhookCreate, WebhookUpdate
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_url_or_raise_422(url: str) -> str:
+    """Validate a webhook URL; convert SSRF/ValueError into ValidationError (422)."""
+    try:
+        return validate_webhook_url(url)
+    except (SSRFBlockedError, ValueError) as exc:
+        raise ValidationError(message=str(exc)) from exc
 
 
 class WebhookService:
@@ -262,7 +281,7 @@ class WebhookService:
     ) -> Webhook:
         """Create a new webhook subscription."""
         # Validate URL against SSRF before storing
-        validate_webhook_url(str(data.url))
+        _validate_url_or_raise_422(str(data.url))
 
         secret = secrets.token_urlsafe(32)
 
@@ -302,7 +321,7 @@ class WebhookService:
         """Update a webhook."""
         # Validate new URL against SSRF if provided
         if data.url is not None:
-            validate_webhook_url(str(data.url))
+            _validate_url_or_raise_422(str(data.url))
 
         webhook = self.get_webhook(webhook_id)
         return webhook_repo.update(self.db, webhook, data)
@@ -343,7 +362,7 @@ class WebhookService:
     ) -> dict:
         """Deliver a payload to a webhook with HMAC signature."""
         # Re-validate URL at delivery time to prevent DNS rebinding attacks
-        validate_webhook_url(webhook.url)
+        _validate_url_or_raise_422(webhook.url)
 
         payload_json = json.dumps(payload, default=str)
         signature = self._create_signature(webhook.secret, payload_json)
@@ -363,6 +382,9 @@ class WebhookService:
         self.db.flush()
 
         try:
+            # SECURITY: follow_redirects defaults to False in httpx.
+            # Do NOT enable it — redirects could bypass SSRF validation
+            # by redirecting to an internal IP after the URL check passes.
             with httpx.Client(timeout=30.0) as client:
                 response = client.post(
                     webhook.url,
@@ -421,13 +443,21 @@ from datetime import UTC, datetime
 
 import httpx
 
-from app.core.exceptions import NotFoundError
-from app.core.sanitize import validate_webhook_url
+from app.core.exceptions import NotFoundError, ValidationError
+from app.core.sanitize import SSRFBlockedError, validate_webhook_url
 from app.db.models.webhook import Webhook, WebhookDelivery
 from app.repositories import webhook_repo
 from app.schemas.webhook import WebhookCreate, WebhookUpdate
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_url_or_raise_422(url: str) -> str:
+    """Validate a webhook URL; convert SSRF/ValueError into ValidationError (422)."""
+    try:
+        return validate_webhook_url(url)
+    except (SSRFBlockedError, ValueError) as exc:
+        raise ValidationError(message=str(exc)) from exc
 
 
 class WebhookService:
@@ -440,7 +470,7 @@ class WebhookService:
     ) -> Webhook:
         """Create a new webhook subscription."""
         # Validate URL against SSRF before storing
-        validate_webhook_url(str(data.url))
+        _validate_url_or_raise_422(str(data.url))
 
         secret = secrets.token_urlsafe(32)
 
@@ -477,7 +507,7 @@ class WebhookService:
         """Update a webhook."""
         # Validate new URL against SSRF if provided
         if data.url is not None:
-            validate_webhook_url(str(data.url))
+            _validate_url_or_raise_422(str(data.url))
 
         webhook = await self.get_webhook(webhook_id)
         return await webhook_repo.update(webhook, data)
@@ -518,7 +548,7 @@ class WebhookService:
     ) -> dict:
         """Deliver a payload to a webhook with HMAC signature."""
         # Re-validate URL at delivery time to prevent DNS rebinding attacks
-        validate_webhook_url(webhook.url)
+        _validate_url_or_raise_422(webhook.url)
 
         payload_json = json.dumps(payload, default=str)
         signature = self._create_signature(webhook.secret, payload_json)
@@ -537,6 +567,9 @@ class WebhookService:
         await delivery.insert()
 
         try:
+            # SECURITY: follow_redirects defaults to False in httpx.
+            # Do NOT enable it — redirects could bypass SSRF validation
+            # by redirecting to an internal IP after the URL check passes.
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     webhook.url,

--- a/template/{{cookiecutter.project_slug}}/backend/app/services/webhook.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/services/webhook.py
@@ -14,6 +14,7 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import NotFoundError
+from app.core.sanitize import validate_webhook_url
 from app.db.models.webhook import Webhook, WebhookDelivery
 from app.repositories import webhook_repo
 from app.schemas.webhook import WebhookCreate, WebhookUpdate
@@ -33,6 +34,9 @@ class WebhookService:
         user_id: UUID | None = None,
     ) -> Webhook:
         """Create a new webhook subscription."""
+        # Validate URL against SSRF before storing
+        validate_webhook_url(str(data.url))
+
         # Generate a secure secret for HMAC signing
         secret = secrets.token_urlsafe(32)
 
@@ -70,6 +74,10 @@ class WebhookService:
         data: WebhookUpdate,
     ) -> Webhook:
         """Update a webhook."""
+        # Validate new URL against SSRF if provided
+        if data.url is not None:
+            validate_webhook_url(str(data.url))
+
         webhook = await self.get_webhook(webhook_id)
         return await webhook_repo.update(self.db, webhook, data)
 
@@ -129,6 +137,9 @@ class WebhookService:
         payload: dict,
     ) -> dict:
         """Deliver a payload to a webhook with HMAC signature."""
+        # Re-validate URL at delivery time to prevent DNS rebinding attacks
+        validate_webhook_url(webhook.url)
+
         payload_json = json.dumps(payload, default=str)
 
         # Create HMAC signature
@@ -230,6 +241,7 @@ import httpx
 from sqlalchemy.orm import Session as DBSession
 
 from app.core.exceptions import NotFoundError
+from app.core.sanitize import validate_webhook_url
 from app.db.models.webhook import Webhook, WebhookDelivery
 from app.repositories import webhook_repo
 from app.schemas.webhook import WebhookCreate, WebhookUpdate
@@ -249,6 +261,9 @@ class WebhookService:
         user_id: str | None = None,
     ) -> Webhook:
         """Create a new webhook subscription."""
+        # Validate URL against SSRF before storing
+        validate_webhook_url(str(data.url))
+
         secret = secrets.token_urlsafe(32)
 
         return webhook_repo.create(
@@ -285,6 +300,10 @@ class WebhookService:
         data: WebhookUpdate,
     ) -> Webhook:
         """Update a webhook."""
+        # Validate new URL against SSRF if provided
+        if data.url is not None:
+            validate_webhook_url(str(data.url))
+
         webhook = self.get_webhook(webhook_id)
         return webhook_repo.update(self.db, webhook, data)
 
@@ -323,6 +342,9 @@ class WebhookService:
         payload: dict,
     ) -> dict:
         """Deliver a payload to a webhook with HMAC signature."""
+        # Re-validate URL at delivery time to prevent DNS rebinding attacks
+        validate_webhook_url(webhook.url)
+
         payload_json = json.dumps(payload, default=str)
         signature = self._create_signature(webhook.secret, payload_json)
 
@@ -400,6 +422,7 @@ from datetime import UTC, datetime
 import httpx
 
 from app.core.exceptions import NotFoundError
+from app.core.sanitize import validate_webhook_url
 from app.db.models.webhook import Webhook, WebhookDelivery
 from app.repositories import webhook_repo
 from app.schemas.webhook import WebhookCreate, WebhookUpdate
@@ -416,6 +439,9 @@ class WebhookService:
         user_id: str | None = None,
     ) -> Webhook:
         """Create a new webhook subscription."""
+        # Validate URL against SSRF before storing
+        validate_webhook_url(str(data.url))
+
         secret = secrets.token_urlsafe(32)
 
         return await webhook_repo.create(
@@ -449,6 +475,10 @@ class WebhookService:
         data: WebhookUpdate,
     ) -> Webhook:
         """Update a webhook."""
+        # Validate new URL against SSRF if provided
+        if data.url is not None:
+            validate_webhook_url(str(data.url))
+
         webhook = await self.get_webhook(webhook_id)
         return await webhook_repo.update(webhook, data)
 
@@ -487,6 +517,9 @@ class WebhookService:
         payload: dict,
     ) -> dict:
         """Deliver a payload to a webhook with HMAC signature."""
+        # Re-validate URL at delivery time to prevent DNS rebinding attacks
+        validate_webhook_url(webhook.url)
+
         payload_json = json.dumps(payload, default=str)
         signature = self._create_signature(webhook.secret, payload_json)
 

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_ssrf.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_ssrf.py
@@ -1,0 +1,217 @@
+"""Tests for SSRF protection in webhook URL validation.
+
+Covers validate_webhook_url() and _is_ip_blocked() from app.core.sanitize.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+# Import directly — this module has no dependencies on database/framework code.
+import sys
+import os
+
+# The sanitize module lives inside the Jinja template tree, but it is plain
+# Python with no cookiecutter variables, so we can import it directly by
+# adding its parent to sys.path.
+_SANITIZE_DIR = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    "app",
+    "core",
+)
+sys.path.insert(0, os.path.normpath(_SANITIZE_DIR))
+
+from sanitize import (  # noqa: E402
+    SSRFBlockedError,
+    _is_ip_blocked,
+    validate_webhook_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_ip_blocked
+# ---------------------------------------------------------------------------
+
+
+class TestIsIpBlocked:
+    """Tests for the _is_ip_blocked helper."""
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "0.0.0.0",
+            "::1",
+            "fe80::1",
+            "fc00::1",
+        ],
+    )
+    def test_blocked_ips(self, ip: str):
+        assert _is_ip_blocked(ip) is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",  # example.com
+            "2606:4700:4700::1111",  # Cloudflare public DNS IPv6
+        ],
+    )
+    def test_allowed_ips(self, ip: str):
+        assert _is_ip_blocked(ip) is False
+
+    def test_unparseable_ip_is_blocked(self):
+        """If we can't parse it, we block it (fail-closed)."""
+        assert _is_ip_blocked("not-an-ip") is True
+
+
+# ---------------------------------------------------------------------------
+# validate_webhook_url — scheme validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemeValidation:
+    """Blocked schemes must raise SSRFBlockedError."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "ftp://mirror.example.com/pub",
+            "gopher://evil.com/",
+            "data:text/html,<h1>hi</h1>",
+        ],
+    )
+    def test_blocked_schemes(self, url: str):
+        with pytest.raises(SSRFBlockedError):
+            validate_webhook_url(url)
+
+    def test_empty_scheme_is_rejected(self):
+        with pytest.raises((SSRFBlockedError, ValueError)):
+            validate_webhook_url("://example.com/hook")
+
+
+# ---------------------------------------------------------------------------
+# validate_webhook_url — IP-literal URLs
+# ---------------------------------------------------------------------------
+
+
+class TestDirectIpUrls:
+    """URLs with IP-address hostnames (no DNS involved)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/hook",
+            "https://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1:8080/callback",
+            "http://192.168.1.1/hook",
+            "http://[::1]/hook",
+            "http://0.0.0.0/hook",
+        ],
+    )
+    def test_private_ip_blocked(self, url: str):
+        with pytest.raises(SSRFBlockedError):
+            validate_webhook_url(url)
+
+    def test_public_ip_allowed(self):
+        """A public IP should pass validation (DNS resolution is skipped)."""
+        url = "https://93.184.216.34/webhook"
+        assert validate_webhook_url(url) == url
+
+
+# ---------------------------------------------------------------------------
+# validate_webhook_url — DNS resolution to private IP
+# ---------------------------------------------------------------------------
+
+
+class TestDnsResolution:
+    """DNS resolving to a private IP must be blocked."""
+
+    def _mock_getaddrinfo_private(self, *args, **kwargs):
+        """Return a private IP for any hostname."""
+        return [
+            (2, 1, 6, "", ("127.0.0.1", 443)),
+        ]
+
+    def _mock_getaddrinfo_public(self, *args, **kwargs):
+        """Return a public IP for any hostname."""
+        return [
+            (2, 1, 6, "", ("93.184.216.34", 443)),
+        ]
+
+    def test_dns_resolves_to_private_ip(self):
+        with patch("sanitize.socket.getaddrinfo", self._mock_getaddrinfo_private):
+            with pytest.raises(SSRFBlockedError):
+                validate_webhook_url("https://evil.attacker.com/hook")
+
+    def test_dns_resolves_to_public_ip(self):
+        with patch("sanitize.socket.getaddrinfo", self._mock_getaddrinfo_public):
+            result = validate_webhook_url("https://example.com/webhook")
+            assert result == "https://example.com/webhook"
+
+
+# ---------------------------------------------------------------------------
+# validate_webhook_url — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases: empty URL, missing hostname, credentials in URL."""
+
+    def test_empty_url(self):
+        with pytest.raises((SSRFBlockedError, ValueError)):
+            validate_webhook_url("")
+
+    def test_no_hostname(self):
+        with pytest.raises(ValueError):
+            validate_webhook_url("https:///path")
+
+    def test_url_with_credentials_rejected(self):
+        """URLs with userinfo (user:pass@) should be rejected."""
+        with pytest.raises(SSRFBlockedError):
+            validate_webhook_url("http://user:pass@internal.example.com/hook")
+
+    def test_url_with_username_only_rejected(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_webhook_url("http://admin@169.254.169.254/")
+
+    def test_allowed_https_url(self):
+        """A normal public URL should pass (mock DNS to avoid network calls)."""
+        with patch(
+            "sanitize.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 443))],
+        ):
+            result = validate_webhook_url("https://example.com/webhook")
+            assert result == "https://example.com/webhook"
+
+    def test_allowed_http_url(self):
+        """An http:// URL to a public IP should also pass."""
+        with patch(
+            "sanitize.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 80))],
+        ):
+            result = validate_webhook_url("http://example.com/webhook")
+            assert result == "http://example.com/webhook"
+
+
+# ---------------------------------------------------------------------------
+# SSRFBlockedError is a subclass of ValueError
+# ---------------------------------------------------------------------------
+
+
+class TestSSRFBlockedError:
+    """The dedicated exception type preserves backward compatibility."""
+
+    def test_is_value_error_subclass(self):
+        assert issubclass(SSRFBlockedError, ValueError)
+
+    def test_catchable_as_value_error(self):
+        with pytest.raises(ValueError):
+            raise SSRFBlockedError("blocked")

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_ssrf.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_ssrf.py
@@ -7,22 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-# Import directly — this module has no dependencies on database/framework code.
-import sys
-import os
-
-# The sanitize module lives inside the Jinja template tree, but it is plain
-# Python with no cookiecutter variables, so we can import it directly by
-# adding its parent to sys.path.
-_SANITIZE_DIR = os.path.join(
-    os.path.dirname(__file__),
-    os.pardir,
-    "app",
-    "core",
-)
-sys.path.insert(0, os.path.normpath(_SANITIZE_DIR))
-
-from sanitize import (  # noqa: E402
+from app.core.sanitize import (
     SSRFBlockedError,
     _is_ip_blocked,
     validate_webhook_url,
@@ -49,6 +34,8 @@ class TestIsIpBlocked:
             "::1",
             "fe80::1",
             "fc00::1",
+            "100.100.100.200",  # CGNAT / Alibaba Cloud metadata
+            "100.64.0.1",  # CGNAT range start (RFC 6598)
         ],
     )
     def test_blocked_ips(self, ip: str):
@@ -114,6 +101,7 @@ class TestDirectIpUrls:
             "http://192.168.1.1/hook",
             "http://[::1]/hook",
             "http://0.0.0.0/hook",
+            "http://100.100.100.200/latest/meta-data/",  # CGNAT / Alibaba metadata
         ],
     )
     def test_private_ip_blocked(self, url: str):
@@ -147,12 +135,14 @@ class TestDnsResolution:
         ]
 
     def test_dns_resolves_to_private_ip(self):
-        with patch("sanitize.socket.getaddrinfo", self._mock_getaddrinfo_private):
-            with pytest.raises(SSRFBlockedError):
-                validate_webhook_url("https://evil.attacker.com/hook")
+        with (
+            patch("app.core.sanitize.socket.getaddrinfo", self._mock_getaddrinfo_private),
+            pytest.raises(SSRFBlockedError),
+        ):
+            validate_webhook_url("https://evil.attacker.com/hook")
 
     def test_dns_resolves_to_public_ip(self):
-        with patch("sanitize.socket.getaddrinfo", self._mock_getaddrinfo_public):
+        with patch("app.core.sanitize.socket.getaddrinfo", self._mock_getaddrinfo_public):
             result = validate_webhook_url("https://example.com/webhook")
             assert result == "https://example.com/webhook"
 
@@ -185,7 +175,7 @@ class TestEdgeCases:
     def test_allowed_https_url(self):
         """A normal public URL should pass (mock DNS to avoid network calls)."""
         with patch(
-            "sanitize.socket.getaddrinfo",
+            "app.core.sanitize.socket.getaddrinfo",
             return_value=[(2, 1, 6, "", ("93.184.216.34", 443))],
         ):
             result = validate_webhook_url("https://example.com/webhook")
@@ -194,7 +184,7 @@ class TestEdgeCases:
     def test_allowed_http_url(self):
         """An http:// URL to a public IP should also pass."""
         with patch(
-            "sanitize.socket.getaddrinfo",
+            "app.core.sanitize.socket.getaddrinfo",
             return_value=[(2, 1, 6, "", ("93.184.216.34", 80))],
         ):
             result = validate_webhook_url("http://example.com/webhook")


### PR DESCRIPTION
## Vulnerability Summary

**CWE-918: Server-Side Request Forgery (SSRF)**
**Severity: High**
**Affected file:** `template/{{cookiecutter.project_slug}}/backend/app/services/webhook.py`

### Data Flow

User-supplied webhook URLs are accepted via the REST API and stored in the database with no server-side validation beyond Pydantic `HttpUrl` (which only validates well-formedness and scheme). When webhook events fire, `WebhookService._deliver()` sends an HTTP POST to the stored URL using `httpx.AsyncClient`. The delivery response body (up to 10KB) is stored in `webhook_deliveries` and accessible via the deliveries API endpoint — creating a **full read SSRF with response exfiltration**.

```
POST /api/v1/webhooks → create_webhook(data.url) → stored in DB
                                                         ↓
Event triggers → _deliver() → httpx.AsyncClient.post(webhook.url) → response stored in DB
                                                         ↓
GET /api/v1/webhooks/{id}/deliveries → attacker reads response body
```

An attacker can target:
- Cloud metadata endpoints (`http://169.254.169.254/latest/meta-data/iam/security-credentials/`)
- Internal services (`http://127.0.0.1:6379`, `http://10.0.0.1:8080/admin`)
- Kubernetes service discovery (`http://kubernetes.default.svc/`)

### Preconditions

- `enable_webhooks` must be `True` during project generation (default: `False`)
- With `use_jwt=True` (default): attacker needs a valid admin JWT (compromised account / insider)
- With `use_jwt=False`: **zero authentication** — any anonymous user can exploit

---

## Fix Description

**Two files changed, 152 lines added:**

### 1. `app/core/sanitize.py` — new `validate_webhook_url()` function

- **Scheme validation**: Only `http` and `https` are allowed (blocks `file://`, `gopher://`, `dict://`)
- **IP literal blocking**: Directly checks if the hostname is a private, reserved, loopback, link-local, multicast, or unspecified IP address using Python `ipaddress` module
- **DNS resolution check**: Resolves hostnames via `socket.getaddrinfo()` and validates that **all** returned addresses are public (blocks DNS-based SSRF bypasses like `localtest.me`, `127.0.0.1.nip.io`)
- Helper `_is_ip_blocked()` uses `ipaddress.ip_address` properties: `is_private`, `is_reserved`, `is_loopback`, `is_link_local`, `is_multicast`, `is_unspecified`

### 2. `app/services/webhook.py` — validation calls at every entry and exit point

All three database variants (PostgreSQL async, SQLite sync, MongoDB) are patched identically:

| Code path | Protection |
|---|---|
| `create_webhook()` | Validates URL **before** storing in DB |
| `update_webhook()` | Validates new URL **when changed** |
| `_deliver()` | Re-validates URL **at delivery time** (defense against DNS rebinding / DB tampering) |

### Rationale

- Validation at **create/update** prevents malicious URLs from entering the system
- Validation at **delivery time** provides defense-in-depth against DNS rebinding (where a hostname resolves to a public IP at creation time but is changed to resolve to an internal IP by delivery time)
- No parallel code paths bypass the validation — `httpx.AsyncClient`/`httpx.Client` is only used in `webhook.py` for outbound requests

---

## Test Results Summary

The fix was verified by:

1. **Blocked URLs** — the following are correctly rejected with `ValueError`:
   - `http://127.0.0.1/` (loopback)
   - `http://169.254.169.254/latest/meta-data/` (AWS metadata / link-local)
   - `http://10.0.0.1/admin` (RFC 1918 private)
   - `http://192.168.1.1/` (RFC 1918 private)
   - `http://[::1]/` (IPv6 loopback)
   - `http://0.0.0.0/` (unspecified)
   - `file:///etc/passwd` (blocked scheme)
   - `gopher://127.0.0.1:6379/` (blocked scheme)

2. **Allowed URLs** — the following pass validation:
   - `https://example.com/webhook`
   - `https://hooks.slack.com/services/...`
   - Any URL resolving to a public IP

3. **DNS resolution check** — hostnames that resolve to private IPs (e.g., `localtest.me` → `127.0.0.1`) are blocked
4. **All three DB variants** (PostgreSQL, SQLite, MongoDB) have identical protection

---

## Disprove Analysis Results

We systematically attempted to invalidate this finding:

| Check | Result |
|---|---|
| **Auth required?** | Conditional — `use_jwt=True` (default) requires admin auth; `use_jwt=False` allows anonymous access. Auth reduces but does not eliminate the attack surface (insider threat, compromised admin). |
| **Network isolation?** | None — `docker-compose.prod.yml` uses Traefik with HTTPS; designed for internet-facing deployment. |
| **Existing validation?** | Pydantic `HttpUrl` validates scheme (http/https) and well-formedness only. **Does NOT block private IPs** — `http://169.254.169.254/...` passes `HttpUrl` validation. |
| **Prior reports?** | None found. |
| **Parallel bypass paths?** | None — all outbound HTTP in webhook.py goes through `_deliver()`. No other user-controlled outbound HTTP in the codebase. |
| **Default exposure?** | `enable_webhooks=False` by default, limiting exposure to projects that explicitly opt in. However, when enabled, the SSRF is fully exploitable. |
| **Existing mitigations?** | `httpx` defaults to `follow_redirects=False`, preventing redirect-based SSRF bypass. This is good but insufficient alone. |

### Known Limitations (acknowledged, non-blocking)

- **TOCTOU window**: Small time gap between `validate_webhook_url` DNS check and `httpx` own DNS resolution during the HTTP request. Mitigated by re-validation at delivery time.
- **Alibaba Cloud metadata** (`100.100.100.200`): Not classified as private/reserved by Python `ipaddress` on some versions. Edge case for Alibaba Cloud deployments.
- **`ValueError` propagation**: The validation raises `ValueError` which may result in HTTP 500 at the API layer instead of 422. Consider adding a catch at the route layer (not blocking for this fix).

### Verdict

**CONFIRMED_VALID** — The vulnerability is real, exploitable, and the fix correctly addresses all code paths. The fix is defense-in-depth that any production webhook implementation should have.

---

## References

- [CWE-918: Server-Side Request Forgery](https://cwe.mitre.org/data/definitions/918.html)
- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
- Similar: GitLab CVE-2021-22214 (webhook SSRF), Slack webhook SSRF disclosures