### PR TITLE
fix: route pydantic_deep OpenAI models to Responses API

### DIFF
--- a/template/{{cookiecutter.project_slug}}/backend/app/agents/pydantic_deep_assistant.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/agents/pydantic_deep_assistant.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 
 # Map LLM_PROVIDER settings value → pydantic-ai provider prefix
 _PROVIDER_PREFIXES: dict[str, str] = {
-    "openai": "openai",
+    "openai": "openai-responses",
     "anthropic": "anthropic",
     "google": "google-gla",  # Google AI (Gemini) via GOOGLE_API_KEY
     "openrouter": "openrouter",
@@ -201,16 +201,21 @@ class PydanticDeepAssistant:
     def _get_model_string(self) -> str:
         """Build pydantic-ai model string with provider prefix.
 
-        If the model name already contains ':', returns it unchanged.
-        Otherwise prepends the provider prefix from LLM_PROVIDER setting.
+        If the model name already contains ':', it is used as-is — except a bare
+        ``openai:`` prefix, which is rewritten to ``openai-responses:`` so it hits
+        the Responses API (tools + reasoning models). Otherwise the prefix from the
+        LLM_PROVIDER setting is prepended.
 
         Examples:
-            "gpt-5.5"             → "openai:gpt-5.5"
+            "gpt-5.5"             → "openai-responses:gpt-5.5"
             "claude-opus-4-7"     → "anthropic:claude-opus-4-7"
             "gemini-2.5-flash"    → "google-gla:gemini-2.5-flash"
-            "openai:gpt-5.5"      → "openai:gpt-5.5"  (unchanged)
+            "openai:gpt-5.5"      → "openai-responses:gpt-5.5"  (rewritten)
+            "openai-responses:gpt-5.5" → "openai-responses:gpt-5.5"  (unchanged)
         """
         if ":" in self.model_name:
+            if self.model_name.startswith("openai:"):
+                return f"openai-responses:{self.model_name.removeprefix('openai:')}"
             return self.model_name
         prefix = _PROVIDER_PREFIXES.get(settings.LLM_PROVIDER, settings.LLM_PROVIDER)
         return f"{prefix}:{self.model_name}"

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_agents.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_agents.py
@@ -295,4 +295,41 @@ class TestHistoryConversion:
         assert isinstance(messages[0], HumanMessage)
         assert isinstance(messages[1], AIMessage)
         assert isinstance(messages[2], SystemMessage)
+{%- elif cookiecutter.use_pydantic_deep %}
+"""Tests for AI agent module (PydanticDeep)."""
+
+from unittest.mock import patch
+
+from app.agents.pydantic_deep_assistant import PydanticDeepAssistant
+
+
+class TestGetModelString:
+    """Tests for PydanticDeepAssistant._get_model_string."""
+
+    def test_openai_provider_uses_responses_api_prefix(self):
+        assistant = PydanticDeepAssistant(model_name="gpt-5.5")
+        with patch("app.agents.pydantic_deep_assistant.settings.LLM_PROVIDER", "openai"):
+            assert assistant._get_model_string() == "openai-responses:gpt-5.5"
+
+    def test_anthropic_provider_prefix(self):
+        assistant = PydanticDeepAssistant(model_name="claude-opus-4-7")
+        with patch("app.agents.pydantic_deep_assistant.settings.LLM_PROVIDER", "anthropic"):
+            assert assistant._get_model_string() == "anthropic:claude-opus-4-7"
+
+    def test_google_provider_prefix(self):
+        assistant = PydanticDeepAssistant(model_name="gemini-2.5-flash")
+        with patch("app.agents.pydantic_deep_assistant.settings.LLM_PROVIDER", "google"):
+            assert assistant._get_model_string() == "google-gla:gemini-2.5-flash"
+
+    def test_explicit_openai_prefix_rewritten_to_responses(self):
+        assistant = PydanticDeepAssistant(model_name="openai:gpt-5.5")
+        assert assistant._get_model_string() == "openai-responses:gpt-5.5"
+
+    def test_explicit_responses_prefix_unchanged(self):
+        assistant = PydanticDeepAssistant(model_name="openai-responses:gpt-5.5")
+        assert assistant._get_model_string() == "openai-responses:gpt-5.5"
+
+    def test_non_openai_explicit_prefix_unchanged(self):
+        assistant = PydanticDeepAssistant(model_name="anthropic:claude-opus-4-7")
+        assert assistant._get_model_string() == "anthropic:claude-opus-4-7"
 {%- endif %}


### PR DESCRIPTION
## Summary

PydanticDeep agents using an OpenAI model (gpt-5+/o-series) crash with HTTP 400:
`Function tools with reasoning_effort are not supported for gpt-5.5 in
/v1/chat/completions. Please use /v1/responses instead.`

Root cause: `pydantic_deep_assistant.py` built a model string with the `openai:`
prefix, which pydantic-ai resolves to `OpenAIChatModel` (Chat Completions API).
That endpoint rejects function tools combined with reasoning models. This routes
OpenAI through the `openai-responses` prefix → `OpenAIResponsesModel` →
`/v1/responses`, consistent with what the standard PydanticAI `assistant.py`
already does.

## Changes

- Map `LLM_PROVIDER=openai` to the `openai-responses` provider prefix in
  `_PROVIDER_PREFIXES` (pydantic_deep_assistant.py)
- Normalize an explicit `openai:` model prefix to `openai-responses:` so a
  user-set `AI_MODEL=openai:gpt-5.5` doesn't bypass the fix via the early return
- Add `TestGetModelString` (6 cases) covering provider prefixes and the
  openai→responses rewrite — pydantic_deep previously had no agent tests

## Testing

- [x] New tests added for any new functionality
- [ ] All tests pass locally: `make test` <!-- not run on the template repo -->
- [ ] Linting passes: `make lint` <!-- ran `ruff check` on the generated file only -->
- [ ] Type checking passes: `make typecheck`
- [x] Generated projects still work: tested with at least one preset

Verified on a generated project (`--ai-framework pydantic_deep --llm-provider
openai --database sqlite`): Jinja renders cleanly, `ruff check` passes, and
`pytest tests/test_agents.py` → 6 passed. Not verified: a live `/v1/responses`
API call (no API key in the harness) — the change is confirmed at the
model-routing level only.

## Related Issues

Fixes #91