### PR TITLE
fix: keep Taskiq worker and scheduler containers healthy

### DIFF
--- a/template/hooks/post_gen_project.py
+++ b/template/hooks/post_gen_project.py
@@ -440,12 +440,14 @@ if not use_any_background_tasks:
     remove_file(os.path.join(worker_dir, "taskiq_app.py"))
     remove_file(os.path.join(worker_dir, "arq_app.py"))
     remove_dir(os.path.join(worker_dir, "tasks"))
+    remove_file(os.path.join(backend_tests, "test_worker_taskiq.py"))
 else:
     if not use_celery:
         remove_file(os.path.join(worker_dir, "celery_app.py"))
     if not use_taskiq:
         remove_file(os.path.join(worker_dir, "taskiq_app.py"))
         remove_file(os.path.join(worker_dir, "tasks", "schedules.py"))
+        remove_file(os.path.join(backend_tests, "test_worker_taskiq.py"))
     if not use_arq:
         remove_file(os.path.join(worker_dir, "arq_app.py"))
 

--- a/template/{{cookiecutter.project_slug}}/backend/app/worker/taskiq_app.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/worker/taskiq_app.py
@@ -2,6 +2,7 @@
 """Taskiq application configuration."""
 
 from taskiq import TaskiqScheduler
+from taskiq.schedule_sources import LabelScheduleSource
 from taskiq_redis import ListQueueBroker, RedisAsyncResultBackend
 
 from app.core.config import settings
@@ -18,7 +19,7 @@ broker = ListQueueBroker(
 # Create scheduler for periodic tasks
 scheduler = TaskiqScheduler(
     broker=broker,
-    sources=["app.worker.tasks.schedules"],
+    sources=[LabelScheduleSource(broker)],
 )
 
 
@@ -33,6 +34,9 @@ async def startup() -> None:
 async def shutdown() -> None:
     """Cleanup on shutdown."""
     pass
+
+
+import app.worker.tasks.schedules  # noqa: F401
 {%- else %}
 # Taskiq not enabled for this project
 {%- endif %}

--- a/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
+++ b/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
@@ -113,7 +113,7 @@ dependencies = [
     "flower>=2.0.0",
 {%- endif %}
 {%- if cookiecutter.use_taskiq %}
-    "taskiq>=0.11.0",
+    "taskiq[reload]>=0.11.0",
     "taskiq-redis>=1.0.0",
     "taskiq-dependencies>=0.1.0",
 {%- endif %}

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_worker_taskiq.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_worker_taskiq.py
@@ -1,0 +1,41 @@
+{%- if cookiecutter.use_taskiq %}
+"""Regression tests for the Taskiq worker/scheduler configuration (issue #92)."""
+
+import sys
+
+import pytest
+from taskiq.schedule_sources import LabelScheduleSource
+
+from app.worker.taskiq_app import broker, scheduler
+
+
+class TestTaskiqScheduler:
+    """The scheduler must receive ScheduleSource instances, not module paths."""
+
+    def test_sources_are_schedule_source_instances(self):
+        """A bare string source crashes startup: 'str' has no attribute 'startup'."""
+        assert scheduler.sources
+        for source in scheduler.sources:
+            assert not isinstance(source, str)
+            assert hasattr(source, "startup")
+
+    def test_uses_label_schedule_source(self):
+        """Schedules are declared via @broker.task(schedule=...) labels."""
+        assert any(isinstance(s, LabelScheduleSource) for s in scheduler.sources)
+
+    @pytest.mark.anyio
+    async def test_scheduler_sources_start_and_list_schedules(self):
+        """Each source starts cleanly and exposes its schedules without error."""
+        for source in scheduler.sources:
+            await source.startup()
+            schedules = await source.get_schedules()
+            assert isinstance(schedules, list)
+
+
+class TestTaskRegistration:
+    """Importing the broker module must register tasks for the worker process."""
+
+    def test_importing_taskiq_app_imports_task_modules(self):
+        """Without this side-effect import the worker discovers zero tasks."""
+        assert "app.worker.tasks.schedules" in sys.modules
+{%- endif %}


### PR DESCRIPTION
## Summary

The Taskiq `worker` and `scheduler` containers crash-loop on startup:

- **worker:** `taskiq worker ... --reload` raises
  `ValueError: To use '--reload' flag, please install 'taskiq[reload]'.`
  — `watchdog` was never installed.
- **scheduler:** `sources=["app.worker.tasks.schedules"]` passed a module-path
  **string** instead of a `ScheduleSource`, so taskiq crashes at
  `await source.startup()` with `AttributeError: 'str' object has no attribute
  'startup'`.

Also fixes a latent bug surfaced while debugging: importing `taskiq_app` alone
registered **zero** tasks, so even a non-crashing worker/scheduler would have
discovered no tasks.

## Changes

- `pyproject.toml`: `taskiq>=0.11.0` → `taskiq[reload]>=0.11.0` (pulls in
  `watchdog`, so `--reload` works in the dev/base compose; prod compose has no
  `--reload`)
- `taskiq_app.py`: use `LabelScheduleSource(broker)` as the schedule source
  (schedules are declared via `@broker.task(schedule=...)` labels)
- `taskiq_app.py`: import `app.worker.tasks.schedules` for its registration
  side-effect, so the worker and scheduler processes actually discover tasks
- Add `tests/test_worker_taskiq.py` — regression tests for both crashes

## Testing

- [x] New tests added for any new functionality
- [ ] All tests pass locally: `make test` <!-- ran the new file + collection on generated projects -->
- [ ] Linting passes: `make lint` <!-- ran `ruff check` on the changed files only -->
- [ ] Type checking passes: `make typecheck`
- [x] Generated projects still work: tested with at least one preset

Verified on generated projects (taskiq + RAG, and minimal taskiq with no
features): reproduced both crashes pre-fix, confirmed they're gone post-fix
(`Observer is not None` → `--reload` guard passes; scheduler `startup()` +
`get_schedules()` succeed; broker registers all tasks). `ruff check` clean,
`pytest tests/test_worker_taskiq.py` → 4 passed in both configs, full pytest
collection → 209 tests, no import cycles. Not run: the full `docker compose`
stack against a live Redis (crashes occur before Redis is contacted).

## Related Issues

Fixes #92

## Notes for Reviewers

No compose-file changes needed: `--reload` stays in dev/base and now works via
`taskiq[reload]`; prod never used it. The bottom-of-file
`import app.worker.tasks.schedules` is intentional (side-effect registration)
and carries a `# noqa: F401`.