### PR TITLE
fix(makefile): use Compose v2 `docker compose` in all targets (#96)

### DIFF
--- a/template/{{cookiecutter.project_slug}}/Makefile
+++ b/template/{{cookiecutter.project_slug}}/Makefile
@@ -283,8 +283,8 @@ taskiq-scheduler:
 
 # === Docker: Backend (Development) ===
 docker-up:
-	docker-compose build app
-	docker-compose up -d
+	docker compose build app
+	docker compose up -d
 	@echo ""
 	@echo "✅ Backend services started!"
 	@echo "   API: http://localhost:{{ cookiecutter.backend_port }}"
@@ -300,25 +300,25 @@ docker-up:
 {%- endif %}
 
 docker-down:
-	docker-compose down
+	docker compose down
 {%- if cookiecutter.use_frontend %}
-	docker-compose -f docker-compose.frontend.yml down 2>/dev/null || true
+	docker compose -f docker-compose.frontend.yml down 2>/dev/null || true
 {%- endif %}
 
 docker-logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 docker-build:
-	docker-compose build
+	docker compose build
 
 docker-shell:
-	docker-compose exec app /bin/bash
+	docker compose exec app /bin/bash
 
 {%- if cookiecutter.use_frontend %}
 
 # === Docker: Frontend (Development) ===
 docker-frontend:
-	docker-compose -f docker-compose.frontend.yml up -d
+	docker compose -f docker-compose.frontend.yml up -d
 	@echo ""
 	@echo "✅ Frontend started!"
 	@echo "   URL: http://localhost:{{ cookiecutter.frontend_port }}"
@@ -326,18 +326,18 @@ docker-frontend:
 	@echo "Note: Backend must be running (make docker-up)"
 
 docker-frontend-down:
-	docker-compose -f docker-compose.frontend.yml down
+	docker compose -f docker-compose.frontend.yml down
 
 docker-frontend-logs:
-	docker-compose -f docker-compose.frontend.yml logs -f
+	docker compose -f docker-compose.frontend.yml logs -f
 
 docker-frontend-build:
-	docker-compose -f docker-compose.frontend.yml build
+	docker compose -f docker-compose.frontend.yml build
 {%- endif %}
 
 # === Docker: Production (with Traefik) ===
 docker-prod:
-	docker-compose -f docker-compose.prod.yml up -d
+	docker compose -f docker-compose.prod.yml up -d
 	@echo ""
 	@echo "✅ Production services started with Traefik!"
 	@echo ""
@@ -352,36 +352,36 @@ docker-prod:
 	@echo "   Traefik: https://traefik.$$DOMAIN"
 
 docker-prod-down:
-	docker-compose -f docker-compose.prod.yml down
+	docker compose -f docker-compose.prod.yml down
 
 docker-prod-logs:
-	docker-compose -f docker-compose.prod.yml logs -f
+	docker compose -f docker-compose.prod.yml logs -f
 
 docker-prod-build:
-	docker-compose -f docker-compose.prod.yml build
+	docker compose -f docker-compose.prod.yml build
 
 {%- if cookiecutter.use_postgresql %}
 
 # === Docker: Individual Services ===
 docker-db:
-	docker-compose up -d db
+	docker compose up -d db
 	@echo ""
 	@echo "✅ PostgreSQL started on port 5432"
 	@echo "   Connection: postgresql://postgres:postgres@localhost:5432/{{ cookiecutter.project_slug }}"
 
 docker-db-stop:
-	docker-compose stop db
+	docker compose stop db
 {%- endif %}
 
 {%- if cookiecutter.enable_redis %}
 
 docker-redis:
-	docker-compose up -d redis
+	docker compose up -d redis
 	@echo ""
 	@echo "✅ Redis started on port 6379"
 
 docker-redis-stop:
-	docker-compose stop redis
+	docker compose stop redis
 {%- endif %}
 
 {%- if cookiecutter.use_frontend %}

--- a/tests/test_template_integration.py
+++ b/tests/test_template_integration.py
@@ -652,3 +652,48 @@ class TestGeneratedDeepResearch:
         content = session.read_text()
         assert "RESEARCH_TOOL_NAMES" not in content
         assert "made_research_call" not in content
+
+
+# ---------------------------------------------------------------------------
+# Makefile — generated-content checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def generated_project_makefile(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Generate a postgres + redis + docker + frontend project for Makefile checks."""
+    config = ProjectConfig(
+        project_name="test_makefile",
+        database=DatabaseType.POSTGRESQL,
+        ai_framework=AIFrameworkType.PYDANTIC_AI,
+        enable_logfire=False,
+        enable_redis=True,
+        frontend=FrontendType.NEXTJS,
+        enable_docker=True,
+        background_tasks=BackgroundTaskType.NONE,
+    )
+    return generate_project(config, tmp_path_factory.mktemp("makefile"))
+
+
+class TestGeneratedMakefile:
+    """Guard the Makefile against the Compose v1 regression in issue #96.
+
+    `make docker-db` (and the other docker-* targets) shelled out to the legacy
+    `docker-compose` binary, which errors with "No such file or directory" on
+    systems that only ship the Compose v2 plugin (`docker compose`).
+    """
+
+    @pytest.mark.slow
+    def test_no_legacy_compose_v1_command(self, generated_project_makefile: Path) -> None:
+        """No recipe may invoke the hyphenated `docker-compose` command."""
+        makefile = (generated_project_makefile / "Makefile").read_text()
+        # The command is `docker-compose ` + args; the `.yml` filenames keep the hyphen.
+        assert "docker-compose " not in makefile
+
+    @pytest.mark.slow
+    def test_docker_db_uses_compose_v2(self, generated_project_makefile: Path) -> None:
+        """The docker-db target must drive the v2 `docker compose` plugin."""
+        makefile = (generated_project_makefile / "Makefile").read_text()
+        assert "docker compose up -d db" in makefile
+        # Compose filenames are still hyphenated — only the command changed.
+        assert "docker-compose.frontend.yml" in makefile


### PR DESCRIPTION
The docker-up/down/build/shell, docker-frontend-*, docker-prod-*, docker-db and docker-redis targets shelled out to the legacy `docker-compose` (v1) binary, while the dev/quickstart targets already used `docker compose` (v2). On systems that only ship the Compose v2 plugin (modern Docker Desktop / Engine, e.g. the reporter's WSL2), `make docker-db` failed with "docker-compose: No such file or directory" (exit 127).

Switch every recipe to `docker compose`. The compose *filenames* (docker-compose.*.yml) are unchanged — only the invoked command. Adds a TestGeneratedMakefile content check so no target regresses to v1.

## Summary

<!-- What does this PR do? What problem does it solve? -->

## Changes

<!-- List the key changes made in this PR -->
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] New tests added for any new functionality
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Generated projects still work: tested with at least one preset

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to? -->
