### PR TITLE
fix(backend): declare dev tools as a PEP 735 dependency group (#95)

### DIFF
--- a/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
+++ b/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
@@ -314,7 +314,11 @@ dependencies = [
 {%- endif %}
 ]
 
-[project.optional-dependencies]
+# PEP 735 dependency group — installed by `uv sync` / `uv sync --dev` and
+# excluded by `--no-dev`. (A `dev` extra under [project.optional-dependencies]
+# only installed via uv's deprecated dev-extra special-casing, so `uv sync --dev`
+# could skip it on some uv versions and leave pre-commit/ruff/ty unspawnable.)
+[dependency-groups]
 dev = [
     "pytest>=9.0.0",
     "anyio[trio]>=4.9.0",

--- a/tests/test_template_integration.py
+++ b/tests/test_template_integration.py
@@ -770,3 +770,37 @@ class TestGeneratedMakefile:
         assert "docker compose up -d db" in makefile
         # Compose filenames are still hyphenated — only the command changed.
         assert "docker-compose.frontend.yml" in makefile
+
+
+# ---------------------------------------------------------------------------
+# Dev dependencies — generated-content checks
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratedDevDependencies:
+    """Guard `make install` against the pre-commit spawn failure in issue #95.
+
+    Dev tools lived under `[project.optional-dependencies].dev`, which only got
+    installed via uv's deprecated `dev`-extra special-casing. On uv versions
+    where `uv sync --dev` targets the PEP 735 group instead, the extra was
+    skipped and `pre-commit`/`ruff`/`ty` were never installed — so `make install`
+    failed with "Failed to spawn: pre-commit". They must live in
+    `[dependency-groups]`, which `--dev` installs deterministically.
+    """
+
+    @pytest.mark.slow
+    def test_dev_tools_in_dependency_group(self, generated_project_makefile: Path) -> None:
+        """Dev tools must be a PEP 735 dependency group, not an optional-deps extra."""
+        pyproject = (generated_project_makefile / "backend" / "pyproject.toml").read_text()
+        assert "[dependency-groups]" in pyproject
+        # The fragile dev-extra form must be gone (check the table header line,
+        # not an incidental mention in a comment).
+        assert "[project.optional-dependencies]" not in pyproject.splitlines()
+
+    @pytest.mark.slow
+    def test_precommit_in_dev_group(self, generated_project_makefile: Path) -> None:
+        """pre-commit must be declared so `uv sync --dev` can install it."""
+        pyproject = (generated_project_makefile / "backend" / "pyproject.toml").read_text()
+        group = pyproject.split("[dependency-groups]", 1)[1]
+        assert "pre-commit" in group
+        assert "ruff" in group and "ty" in group


### PR DESCRIPTION
`make install` ran `uv sync --directory backend --dev` then `uv run pre-commit install`, but the dev tools lived under `[project.optional-dependencies].dev`. uv only installs a `dev` *extra* via its deprecated dev-extra special-casing; on uv versions where `--dev` targets the PEP 735 group instead, the extra is skipped and pre-commit/ruff/ty are never installed — so `make install` died with "Failed to spawn: pre-commit".

Move the dev tools to `[dependency-groups]` (PEP 735): installed by `uv sync` and `uv sync --dev`, excluded by `--no-dev` (prod Dockerfile). All existing call sites (Makefile, CI, Dockerfile) already use --dev/--no-dev, so they keep working. Verified end-to-end: `git init && make install` now installs the hook.

Adds TestGeneratedDevDependencies. The companion ".env not pre-configured" report was already resolved on main: the message is gated on generate_env and post_gen actually writes backend/.env when it is on.

## Summary

<!-- What does this PR do? What problem does it solve? -->

## Changes

<!-- List the key changes made in this PR -->
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] New tests added for any new functionality
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Generated projects still work: tested with at least one preset

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to? -->
