### PR TITLE
fix(#119): reduce always-loaded CLAUDE.md, add anti-duplication guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "click>=8.3.0",
+    "click>=8.3.3",
     "cookiecutter>=2.7.0",
     "rich>=15.0.0",
     "questionary>=2.1.0",

--- a/template/{{cookiecutter.project_slug}}/CLAUDE.md
+++ b/template/{{cookiecutter.project_slug}}/CLAUDE.md
@@ -65,123 +65,28 @@ uv run {{ cookiecutter.project_slug }} cmd rag-source-sync
 {%- endif %}
 ```
 
-## Project Structure
+## Hard Boundaries
 
-```
-backend/app/
-├── main.py               # FastAPI app with lifespan (startup/shutdown)
-├── api/
-│   ├── deps.py           # Annotated DI aliases (DBSession, CurrentUser, *Svc)
-│   ├── exception_handlers.py
-│   └── routes/v1/        # HTTP endpoints — call services, never repos
-├── core/
-│   ├── config.py         # pydantic-settings Settings class
-│   ├── security.py       # JWT (PyJWT), bcrypt password hashing, API key verification
-│   ├── exceptions.py     # Domain exceptions (AppException → NotFoundError, etc.)
-│   └── middleware.py      # RequestID, SecurityHeaders, CORS
-├── db/
-│   ├── base.py           # DeclarativeBase, TimestampMixin, naming convention
-│   ├── session.py        # Engine, async_session_maker, get_db_session (auto-commit)
-│   └── models/           # SQLAlchemy models (Mapped[] type hints)
-├── schemas/              # Pydantic v2 models: *Create, *Update, *Read, *List
-├── repositories/         # Data access functions — db.flush(), never commit
-├── services/             # Business logic — flat *.py for thin domains, subpackage for thick
-│   ├── user.py           #   thin: just a class with db + repo calls
-{%- if cookiecutter.enable_billing %}
-│   ├── billing/          #   thick: facade + sub-services + Stripe client + handlers
+Non-obvious rules that are easy to violate and cross-cutting enough to state up front:
+
+- Repositories use `db.flush()` + `db.refresh()`, **never** `db.commit()` — the session auto-commits via `get_db_session`.
+- Routes call services only — **never** import or call repositories directly.
+- Route handlers return `-> Any`; serialization is handled by `response_model` (avoids double Pydantic validation).
+- `datetime.now(UTC)`, never `datetime.utcnow()`.
+- `secrets.compare_digest()` for API key comparison, never `==`.
+
+## Detailed Conventions
+
+Path-scoped guidance lives in `.claude/rules/*` and loads automatically when you edit matching files — it is intentionally NOT repeated here:
+
+- `architecture.md` — Routes → Services → Repositories, dependency injection, thin vs. thick domains
+- `schemas-models.md` — Pydantic v2 schemas (`*Create`/`*Update`/`*Read`/`*List`), SQLAlchemy models
+- `api-conventions.md` — REST structure, status codes, response format, pagination, auth
+- `exceptions-security.md` — domain exceptions (`NotFoundError`, etc.), JWT, RBAC
+- `code-style.md` — formatting, naming, imports, type hints
+- `testing.md` — test structure, fixtures, async patterns
+{%- if cookiecutter.use_frontend %}
+- `frontend.md` — Next.js 15 conventions
 {%- endif %}
-{%- if cookiecutter.enable_rag %}
-│   ├── rag/              #   thick: ingestion + vectorstore + embeddings + connectors
-{%- endif %}
-{%- if cookiecutter.use_telegram or cookiecutter.use_slack %}
-│   ├── channels/         #   thick: Slack/Telegram adapters + router
-{%- endif %}
-{%- if cookiecutter.enable_email %}
-│   └── email/            #   thick: providers + templates
-{%- endif %}
-├── agents/               # AI agent wrappers + tools
-├── worker/               # Background tasks (Celery/Taskiq/ARQ + in-process)
-└── commands/             # CLI commands (auto-discovered)
-```
 
-## Architecture: Routes → Services → Repositories
-
-**Routes** (`api/routes/v1/`) — HTTP layer only: validate input via Pydantic, call service, return response. Never import repositories.
-
-**Services** (`services/`) — Business logic: class with `__init__(self, db)`, orchestrate repos, raise domain exceptions (`NotFoundError`, `AlreadyExistsError`, etc.).
-
-**Repositories** (`repositories/`) — Pure data access functions. Always use `db.flush()` + `db.refresh()`, NEVER `db.commit()`. Session auto-commits via `get_db_session`.
-
-## Dependency Injection Pattern
-
-All DI uses `Annotated` type aliases defined in `api/deps.py`:
-
-```python
-# deps.py
-DBSession = Annotated[AsyncSession, Depends(get_db_session)]
-UserSvc = Annotated[UserService, Depends(get_user_service)]
-CurrentUser = Annotated[User, Depends(get_current_user)]
-CurrentAdmin = Annotated[User, Depends(RoleChecker(UserRole.ADMIN))]
-
-# Route usage — no raw Depends() in function signatures
-@router.get("/{id}", response_model=ConversationRead)
-async def get_conversation(
-    id: UUID, service: ConversationSvc, user: CurrentUser
-) -> Any:
-    return await service.get(id, user_id=user.id)
-```
-
-## Schema Conventions (Pydantic v2)
-
-- Base: `BaseSchema` with `ConfigDict(from_attributes=True, str_strip_whitespace=True)`
-- Separate models per operation: `*Create`, `*Update`, `*Read`
-- List responses: `*List` with `items: list[*Read]` and `total: int`
-- Update schemas: all fields `Optional` (`str | None = None`)
-- Use `Field(max_length=255)`, `Field(min_length=8)`, `EmailStr`
-- `@field_validator` for complex deserialization (e.g., JSON string → dict)
-- IDs are `UUID` type
-
-## Exception Handling
-
-Domain exceptions in `core/exceptions.py` — all extend `AppException`:
-
-| Exception | HTTP | Code |
-|-----------|------|------|
-| `NotFoundError` | 404 | `NOT_FOUND` |
-| `AlreadyExistsError` | 409 | `ALREADY_EXISTS` |
-| `ValidationError` | 422 | `VALIDATION_ERROR` |
-| `AuthenticationError` | 401 | `AUTHENTICATION_ERROR` |
-| `AuthorizationError` | 403 | `AUTHORIZATION_ERROR` |
-| `BadRequestError` | 400 | `BAD_REQUEST` |
-| `ExternalServiceError` | 503 | `EXTERNAL_SERVICE_ERROR` |
-
-Always pass `message` and `details` dict: `raise NotFoundError(message="User not found", details={"user_id": id})`
-
-## Response Format
-
-```python
-# Single item — use response_model
-@router.get("/{id}", response_model=ConversationRead)
-
-# List — return *List schema
-@router.get("", response_model=ConversationList)
-
-# Create — 201
-@router.post("", response_model=UserRead, status_code=status.HTTP_201_CREATED)
-
-# Delete — 204, no body
-@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
-
-# All route return types are -> Any (avoids double Pydantic validation)
-```
-
-## Key Conventions
-
-- Return type `-> Any` on route handlers (response_model handles serialization)
-- Use `Query(default, ge=0, le=100, description="...")` for query params
-- Keyword-only args in repo functions: `create(db, *, email: str, name: str)`
-- `__repr__` on all DB models
-- `datetime.now(UTC)` not `datetime.utcnow()`
-- `secrets.compare_digest()` for API key comparison
-- `TypedDict` for lifespan state
-- Imports: stdlib → third-party → local, with `TYPE_CHECKING` block for circular refs
+Longer-form docs: `docs/architecture.md`, `docs/adding_features.md`, `docs/testing.md`, `docs/patterns.md`.

--- a/tests/test_context_files.py
+++ b/tests/test_context_files.py
@@ -1,0 +1,92 @@
+"""Anti-duplication guard for generated agent context files.
+
+Background: the June 2026 revision of *Are Repository-Level Context Files
+Helpful for Coding Agents?* (https://arxiv.org/abs/2602.11988) found that
+always-loaded repository context files raise inference cost while repository
+overviews (directory trees) don't improve task success. The useful content is
+narrow: non-inferable commands, hard boundaries, and pointers.
+
+The generated root ``CLAUDE.md`` is always loaded, while ``.claude/rules/*``
+files are path-scoped (they carry ``globs:`` frontmatter and load only when a
+matching file is edited). So any convention detailed in a rules file must NOT
+also live in the always-loaded root file, or that guidance loads twice.
+
+This guard is intentionally deterministic — a denylist of section headings plus
+a line budget — rather than a fuzzy semantic diff, so the check itself stays
+stable (issue #119).
+
+``AGENTS.md`` is deliberately exempt: non-Claude agents (Codex, Cursor,
+Copilot, ...) do not read ``.claude/rules/*``, so it must stay self-contained.
+"""
+
+from pathlib import Path
+
+import pytest
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "template"
+PROJECT_ROOT = TEMPLATE_DIR / "{{cookiecutter.project_slug}}"
+CLAUDE_MD = PROJECT_ROOT / "CLAUDE.md"
+
+# Section headings whose detail belongs in .claude/rules/* and must not be
+# restated in the always-loaded root CLAUDE.md. Matched case-insensitively as
+# markdown headings.
+BANNED_HEADINGS = (
+    "Project Structure",
+    "Dependency Injection",
+    "Schema Conventions",
+    "Exception Handling",
+    "Response Format",
+    "Key Conventions",
+)
+
+# The reduced root file must stay small; this backstops gradual regrowth.
+MAX_LINES = 110
+
+
+class TestClaudeMdIsReduced:
+    """Root CLAUDE.md must stay an index, not a duplicate of the scoped rules."""
+
+    @pytest.fixture
+    def content(self) -> str:
+        assert CLAUDE_MD.exists(), f"CLAUDE.md not found at {CLAUDE_MD}"
+        return CLAUDE_MD.read_text()
+
+    def test_no_banned_sections(self, content: str) -> None:
+        """No section already covered by .claude/rules/* may appear here."""
+        headings = {
+            line.lstrip("#").strip().lower()
+            for line in content.splitlines()
+            if line.lstrip().startswith("#")
+        }
+        offenders = [
+            banned
+            for banned in BANNED_HEADINGS
+            if any(banned.lower() in heading for heading in headings)
+        ]
+        assert not offenders, (
+            "CLAUDE.md restates sections that belong in .claude/rules/* "
+            f"(duplicated always-loaded guidance): {offenders}"
+        )
+
+    def test_no_directory_tree(self, content: str) -> None:
+        """The generated directory tree does not improve outcomes — keep it out."""
+        tree_lines = [line for line in content.splitlines() if "├──" in line or "└──" in line]
+        assert not tree_lines, (
+            "CLAUDE.md contains a directory tree; repository overviews are "
+            f"unhelpful always-loaded context. First offending line: {tree_lines[0]!r}"
+        )
+
+    def test_within_line_budget(self, content: str) -> None:
+        """Line budget prevents the reduced file from silently regrowing."""
+        line_count = len(content.splitlines())
+        assert line_count <= MAX_LINES, (
+            f"CLAUDE.md has {line_count} lines (budget {MAX_LINES}). Move detail "
+            "into .claude/rules/* instead of growing the always-loaded root file."
+        )
+
+    def test_keeps_useful_content(self, content: str) -> None:
+        """The reduced file must still carry the non-inferable, useful parts."""
+        assert "## Commands" in content, "CLAUDE.md must keep the Commands section"
+        assert ".claude/rules" in content, (
+            "CLAUDE.md must point to the scoped .claude/rules/* files"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -390,14 +390,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-fullstack"
-version = "0.2.13"
+version = "0.2.15"
 source = { editable = "." }
 dependencies = [
     { name = "arq" },
@@ -646,7 +646,7 @@ dev = [
 requires-dist = [
     { name = "arq", specifier = ">=0.28.0" },
     { name = "celery", specifier = ">=5.6.3" },
-    { name = "click", specifier = ">=8.3.0" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cookiecutter", specifier = ">=2.7.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Changes

### Summary

Reduce the generated root `CLAUDE.md` from 187 to 92 lines so it only carries non-inferable content (commands, hard boundaries, pointers), and add a deterministic CI guard that prevents the always-loaded context from regrowing or duplicating the path-scoped rules.

### Business Context

The template distributes `AGENTS.md` / `CLAUDE.md` at scale, so any context bloat is multiplied across every generated project. `CLAUDE.md` is always loaded, while `.claude/rules/*` files are path-scoped (they carry `globs:` frontmatter and load only when a matching file is edited). The root file restated architecture, DI, schema, exception, response-format and convention sections that already live in those rules, plus a directory-tree overview — i.e. duplicated always-loaded guidance. The June 2026 revision of *Are Repository-Level Context Files Helpful for Coding Agents?* ([arxiv 2602.11988](https://arxiv.org/abs/2602.11988)) found always-loaded context files raise inference cost while repository overviews don't improve task success; the useful case is narrow (custom commands, unusual conventions, hard boundaries). Discussed and agreed in #119.

### Changes

- **Trim `template/{{cookiecutter.project_slug}}/CLAUDE.md`** to: Project Overview (one-line stack), full `## Commands`, a new `## Hard Boundaries` (5 easy-to-violate cross-cutting rules), and `## Detailed Conventions` pointing to `.claude/rules/*` and `docs/`. Drops the directory tree and the sections duplicated in the scoped rules.
- **Add `tests/test_context_files.py`** — a deterministic guard (kept as a denylist + line budget rather than a fuzzy semantic diff, so the check itself stays stable):
  - banned-heading denylist — sections covered by `.claude/rules/*` must be absent from the root file;
  - no directory tree (`├──` / `└──`);
  - line budget (≤ 110) to stop gradual regrowth;
  - required content — must keep `## Commands` and pointers to `.claude/rules`.
- **`AGENTS.md` left intact** — non-Claude agents (Codex, Cursor, Copilot, ...) don't read `.claude/rules/*`, so it must stay self-contained.

The guard is wired into CI automatically: the main job already runs `uv run pytest`, which collects the new test.

### Verification

Full suite green, including the integration tests that generate real projects (so the reduced `CLAUDE.md` doesn't break generation):

```
$ uv run pytest tests/test_template_docs.py tests/test_template_integration.py tests/test_context_files.py -q
tests/test_template_docs.py ....                                         [  6%]
tests/test_template_integration.py .....................................
...................                                                      [ 93%]
tests/test_context_files.py ....                                         [100%]
======================== 64 passed in 142.87s (0:02:22) ========================
```

Guard actually fails on a regression — appending a banned `## Exception Handling` section and a directory tree to the reduced file is caught by both `test_no_banned_sections` (`['Exception Handling']`) and `test_no_directory_tree` (`True`).

### Linked Issues

Closes #119
