### PR TITLE
fix(mcp): close the gaps the MCP client shipped with

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1189,6 +1189,100 @@ jobs:
           SECRET_KEY: test-secret-key-for-ci-that-is-long-enough
         run: uv run pytest -v
 
+  generate-pg-mcp-client:
+    name: Template - PostgreSQL + MCP Client
+    needs: [lint, type-check]
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install generator
+        run: uv sync
+
+      # --slack renders app/services/agent_invocation.py, the second place the
+      # PydanticAI agent is built — it attaches the user's MCP toolsets too.
+      - name: Generate project with the MCP client
+        run: |
+          mkdir -p /tmp/projects
+          uv run fastapi-fullstack create test_mcp_client \
+            --database postgresql \
+            --ai-framework pydantic_ai \
+            --frontend nextjs \
+            --slack \
+            --mcp-client \
+            -o /tmp/projects
+
+      - name: Install backend
+        working-directory: /tmp/projects/test_mcp_client/backend
+        run: uv sync --dev
+
+      - name: Run linting
+        working-directory: /tmp/projects/test_mcp_client/backend
+        run: |
+          uv run ruff check .
+          uv run ruff format --check .
+
+      - name: Run type check
+        working-directory: /tmp/projects/test_mcp_client/backend
+        run: uv run ty check
+
+      - name: Run tests
+        working-directory: /tmp/projects/test_mcp_client/backend
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+          SECRET_KEY: test-secret-key-for-ci-that-is-long-enough
+        run: uv run pytest -v
+
+      - name: Install frontend dependencies
+        working-directory: /tmp/projects/test_mcp_client/frontend
+        run: bun install
+
+      - name: Run frontend lint
+        working-directory: /tmp/projects/test_mcp_client/frontend
+        run: bun run lint
+
+      - name: Run frontend type check
+        working-directory: /tmp/projects/test_mcp_client/frontend
+        run: bun run type-check
+
+      - name: Run frontend unit tests
+        working-directory: /tmp/projects/test_mcp_client/frontend
+        run: bun run test:run
+
   generate-pg-monitoring:
     name: Template - PostgreSQL + ARQ + Sentry + Prometheus + Caching
     needs: [lint, type-check]

--- a/template/{{cookiecutter.project_slug}}/backend/.env.example
+++ b/template/{{cookiecutter.project_slug}}/backend/.env.example
@@ -250,7 +250,11 @@ DEEP_RESEARCH_COMPRESS_THRESHOLD=0.8
 # === MCP Client (Settings → Integrations) ===
 # Deployment-managed MCP servers, always attached on top of each user's own
 # connections. JSON list; leave empty to rely purely on per-user connections.
-# MCP_SERVERS=[{"name":"github","url":"https://api.githubcopilot.com/mcp/","headers":{"Authorization":"Bearer ghp_..."},"allowed_tools":["search_issues"]}]
+# "name" is a slug (lowercase letters, digits, hyphens) and becomes the prefix
+# of that server's tool names, so it must not clash with a name your users can
+# pick in the marketplace — a clash means their connection is dropped in favour
+# of this one. Startup fails on a malformed or duplicated name.
+# MCP_SERVERS=[{"name":"github-internal","url":"https://api.githubcopilot.com/mcp/","headers":{"Authorization":"Bearer ghp_..."},"allowed_tools":["search_issues"]}]
 MCP_SERVERS=[]
 # Per-server budget for the pre-flight ping; unreachable servers are skipped.
 MCP_CONNECT_TIMEOUT_SECS=3

--- a/template/{{cookiecutter.project_slug}}/backend/app/agents/mcp_oauth.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/agents/mcp_oauth.py
@@ -54,6 +54,12 @@ logger = logging.getLogger(__name__)
 # How long an access token must still be valid to be reused without refreshing.
 TOKEN_EXPIRY_SKEW_SECS = 60.0
 
+# How long a consent redirect stays redeemable. The ``state`` token is the only
+# thing authenticating the callback, and it travels through the provider and the
+# browser's history — so a flow the user never finished must stop working rather
+# than sit in the database indefinitely.
+FLOW_TTL_SECS = 600.0
+
 # Redirects are followed by hand (see _send) so every hop is SSRF-checked.
 _MAX_REDIRECTS = 5
 
@@ -101,6 +107,8 @@ class McpOAuthPayload(BaseModel):
     # only once tokens arrive, so a re-authorization that points at a new URL
     # cannot move the connection while the old tokens are still stored.
     server_url: str
+    # Epoch seconds when the consent redirect was issued — see FLOW_TTL_SECS.
+    started_at: float
     authorization_endpoint: str
     token_endpoint: str
     registration_endpoint: str | None = None

--- a/template/{{cookiecutter.project_slug}}/backend/app/core/config.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/core/config.py
@@ -12,17 +12,24 @@ from pydantic import field_validator, model_validator{% if cookiecutter.use_jwt 
 {% endif -%}
 from pydantic_settings import BaseSettings, SettingsConfigDict
 {%- if cookiecutter.enable_mcp_client %}
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 {%- endif %}
 
 
 {%- if cookiecutter.enable_mcp_client %}
 
 
+# Same slug rule as a user connection (app/schemas/mcp_connection.py). The name
+# becomes the server's tool prefix in the agent, so an unconstrained name could
+# collapse two servers onto one prefix — and the second would then be dropped
+# from every chat turn. Reject it at startup instead.
+MCP_SERVER_NAME_PATTERN = r"^[a-z0-9][a-z0-9-]{0,31}$"
+
+
 class McpServerConfig(BaseModel):
     """One deployment-managed MCP server (see MCP_SERVERS below)."""
 
-    name: str
+    name: str = Field(pattern=MCP_SERVER_NAME_PATTERN)
     url: str
     headers: dict[str, str] = {}
     # None = expose every tool the server offers.
@@ -407,13 +414,24 @@ class Settings(BaseSettings):
     # Deployment-managed MCP servers, always attached to the agent (on top of
     # the per-user connections configured in Settings → Integrations).
     # JSON list, e.g.:
-    #   MCP_SERVERS='[{"name":"github","url":"https://api.githubcopilot.com/mcp/",
+    #   MCP_SERVERS='[{"name":"github-internal","url":"https://api.githubcopilot.com/mcp/",
     #                  "headers":{"Authorization":"Bearer ..."},
     #                  "allowed_tools":["search_issues"]}]'
     MCP_SERVERS: list[McpServerConfig] = []
     # Per-server budget for the pre-flight tools/list ping; unreachable servers
     # are skipped for the turn instead of failing the chat.
     MCP_CONNECT_TIMEOUT_SECS: float = 3.0
+
+    @field_validator("MCP_SERVERS")
+    @classmethod
+    def validate_mcp_server_names(cls, v: list[McpServerConfig]) -> list[McpServerConfig]:
+        """Reject duplicate names: they share a tool prefix, and the agent can
+        only attach one server per prefix — the rest would vanish silently."""
+        names = [server.name for server in v]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise ValueError(f"MCP_SERVERS has duplicate server names: {', '.join(duplicates)}")
+        return v
 {%- endif %}
 {%- if cookiecutter.use_deepagents %}
 

--- a/template/{{cookiecutter.project_slug}}/backend/app/repositories/mcp_connection.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/repositories/mcp_connection.py
@@ -7,12 +7,32 @@ from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import lazyload
 
 from app.db.models.mcp_connection import McpConnection
 
 
 async def get_by_id(db: AsyncSession, connection_id: UUID) -> McpConnection | None:
     result = await db.execute(select(McpConnection).where(McpConnection.id == connection_id))
+    return result.scalar_one_or_none()
+
+
+async def get_by_id_for_update(db: AsyncSession, connection_id: UUID) -> McpConnection | None:
+    """Fetch a connection and lock the row (``SELECT ... FOR UPDATE``).
+
+    Used before spending an OAuth refresh token, so two concurrent chat turns
+    can't both redeem it. ``lazyload`` drops the model's eager join on ``users``
+    (PostgreSQL refuses ``FOR UPDATE`` on the nullable side of an outer join),
+    and ``populate_existing`` re-reads the columns so the caller sees what the
+    other transaction committed rather than the stale identity-map copy.
+    """
+    result = await db.execute(
+        select(McpConnection)
+        .where(McpConnection.id == connection_id)
+        .options(lazyload(McpConnection.user))
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
     return result.scalar_one_or_none()
 
 

--- a/template/{{cookiecutter.project_slug}}/backend/app/services/agent_invocation.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/services/agent_invocation.py
@@ -18,6 +18,9 @@ from app.repositories import knowledge_base_repo
 from app.agents.assistant import Deps, get_agent
 from app.services.agent import build_message_history
 {%- endif %}
+{%- if cookiecutter.enable_mcp_client %}
+from app.services.mcp_connection import build_toolsets_for_user
+{%- endif %}
 {%- if cookiecutter.use_pydantic_deep %}
 from app.agents.pydantic_deep_assistant import PydanticDeepAssistant, PydanticDeepContext
 {%- endif %}
@@ -147,7 +150,15 @@ class AgentInvocationService:
         """Invoke PydanticAI agent and extract tool events from result messages."""
 
         model_name: str | None = kwargs.get("model_override")
+{%- if cookiecutter.enable_mcp_client %}
+        # Channel messages run the same agent as the web chat, so the user's
+        # Settings → Integrations servers apply here too. Traffic with no mapped
+        # account still gets the deployment-managed MCP_SERVERS.
+        mcp_toolsets = await build_toolsets_for_user(kwargs.get("user_id"))
+        assistant = get_agent(model_name=model_name, extra_toolsets=mcp_toolsets)
+{%- else %}
         assistant = get_agent(model_name=model_name)
+{%- endif %}
 
         model_history = build_message_history(history)
         deps = Deps(kb_collection_names=kwargs.get("kb_collection_names") or [])

--- a/template/{{cookiecutter.project_slug}}/backend/app/services/mcp_connection.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/services/mcp_connection.py
@@ -67,29 +67,53 @@ def _apply_token(payload: McpOAuthPayload, token: OAuthToken) -> McpOAuthPayload
     )
 
 
-async def _oauth_access_token(db: AsyncSession, connection: McpConnection) -> str | None:
-    """A currently-valid access token for an OAuth connection, refreshing and
-    persisting if needed. None when the connection isn't authorized yet, its
-    token expired with no refresh path, or the payload can't be decrypted."""
-    if not connection.oauth_payload:
+def _decode_payload(encrypted: str | None, connection_name: str) -> McpOAuthPayload | None:
+    """Decrypt a stored OAuth payload, or None if it can't be read.
+
+    An unreadable payload means the SECRET_KEY was rotated (or the row was
+    tampered with). That's a dead connection the user has to re-authorize, not
+    a reason to fail the chat turn.
+    """
+    if not encrypted:
         return None
     try:
-        payload = McpOAuthPayload.model_validate_json(
-            decrypt_value(connection.oauth_payload, settings.SECRET_KEY)
-        )
+        return McpOAuthPayload.model_validate_json(decrypt_value(encrypted, settings.SECRET_KEY))
     except Exception:
-        logger.warning("Cannot decrypt OAuth payload for MCP connection %r", connection.name)
+        logger.warning("Cannot decrypt OAuth payload for MCP connection %r", connection_name)
         return None
-    if not payload.access_token:
-        return None  # awaiting consent
-    fresh_enough = (
+
+
+def _token_is_fresh(payload: McpOAuthPayload) -> bool:
+    """True when the stored access token is good for at least the skew window."""
+    return (
         payload.expires_at is None
         or _now_epoch() < payload.expires_at - mcp_oauth.TOKEN_EXPIRY_SKEW_SECS
     )
-    if fresh_enough:
-        return payload.access_token
+
+
+async def _refresh_under_lock(db: AsyncSession, connection: McpConnection) -> str | None:
+    """Spend the refresh token for *connection* while holding its row lock.
+
+    Two chat turns for the same user can reach an expired token at the same
+    moment. Providers that rotate refresh tokens invalidate whichever copy is
+    redeemed second, and the connection then stops working with no visible
+    cause. The lock makes the loser wait, re-read the row, and find the token
+    the winner already stored.
+
+    A turn can end up holding several of these at once; they're always taken in
+    ``list_for_user`` order (created_at ascending), so two turns can't deadlock
+    by grabbing the same pair of rows in opposite orders.
+    """
+    locked = await mcp_connection_repo.get_by_id_for_update(db, connection.id)
+    if locked is None:
+        return None
+    payload = _decode_payload(locked.oauth_payload, connection.name)
+    if payload is None or not payload.access_token:
+        return None
+    if _token_is_fresh(payload):
+        return payload.access_token  # another turn refreshed while we waited
     if not payload.refresh_token:
-        return None  # expired, no refresh token → user must re-authorize
+        return None
     try:
         token = await mcp_oauth.refresh_tokens(
             token_endpoint=payload.token_endpoint,
@@ -105,12 +129,26 @@ async def _oauth_access_token(db: AsyncSession, connection: McpConnection) -> st
     payload = _apply_token(payload, token)
     await mcp_connection_repo.update(
         db,
-        db_connection=connection,
+        db_connection=locked,
         update_data={
             "oauth_payload": encrypt_value(payload.model_dump_json(), settings.SECRET_KEY)
         },
     )
     return payload.access_token
+
+
+async def _oauth_access_token(db: AsyncSession, connection: McpConnection) -> str | None:
+    """A currently-valid access token for an OAuth connection, refreshing and
+    persisting if needed. None when the connection isn't authorized yet, its
+    token expired with no refresh path, or the payload can't be decrypted."""
+    payload = _decode_payload(connection.oauth_payload, connection.name)
+    if payload is None or not payload.access_token:
+        return None  # not authorized yet, or an unreadable payload
+    if _token_is_fresh(payload):
+        return payload.access_token
+    if not payload.refresh_token:
+        return None  # expired, no refresh token → user must re-authorize
+    return await _refresh_under_lock(db, connection)
 
 
 async def _resolve_auth_headers(
@@ -251,7 +289,8 @@ class McpConnectionService:
         Starting again with the same name re-authorizes the existing OAuth
         connection: the live tokens in ``oauth_payload`` are left untouched
         until the callback succeeds, so abandoning the consent screen leaves a
-        working connection working.
+        working connection working. The pending flow stops being redeemable
+        after ``mcp_oauth.FLOW_TTL_SECS``.
         """
         url = await validate_mcp_url(url)
         server = await mcp_oauth.discover(url)  # raises OAuthError if unsupported
@@ -261,6 +300,7 @@ class McpConnectionService:
         state = secrets.token_urlsafe(32)
         payload = McpOAuthPayload(
             server_url=url,
+            started_at=_now_epoch(),
             authorization_endpoint=server.authorization_endpoint,
             token_endpoint=server.token_endpoint,
             registration_endpoint=server.registration_endpoint,
@@ -323,10 +363,10 @@ class McpConnectionService:
         connection = await mcp_connection_repo.get_by_oauth_state(self.db, state)
         if connection is None or not connection.oauth_pending_payload:
             raise NotFoundError(message="OAuth session not found or already completed")
-        payload = McpOAuthPayload.model_validate_json(
-            decrypt_value(connection.oauth_pending_payload, settings.SECRET_KEY)
-        )
-        if not payload.code_verifier:
+        payload = _decode_payload(connection.oauth_pending_payload, connection.name)
+        if payload is None or not payload.code_verifier:
+            raise OAuthError("This authorization session is no longer valid — start again.")
+        if _now_epoch() - payload.started_at > mcp_oauth.FLOW_TTL_SECS:
             raise OAuthError("This authorization session has expired — start again.")
         token = await mcp_oauth.exchange_code(
             token_endpoint=payload.token_endpoint,
@@ -363,27 +403,35 @@ class McpConnectionService:
         return db_connection
 
 
-async def build_toolsets_for_user(user_id: UUID) -> list[Any]:
+async def build_toolsets_for_user(user_id: UUID | None) -> list[Any]:
     """Agent toolsets for one chat turn: static MCP_SERVERS + the user's
-    enabled connections. Unreachable servers are skipped, never fatal."""
+    enabled connections. Unreachable servers are skipped, never fatal.
+
+    ``user_id`` is None for channel traffic that isn't mapped to an account;
+    the deployment-managed servers still apply, there are just no per-user
+    connections to add.
+    """
     specs = static_server_specs()
-    async with get_db_context() as db:
-        connections, _ = await mcp_connection_repo.list_for_user(
-            db, user_id=user_id, enabled_only=True
-        )
-        for connection in connections:
-            headers = await _resolve_auth_headers(db, connection)
-            if headers is None:
-                # OAuth not authorized / expired, or an undecryptable bearer token
-                # (e.g. SECRET_KEY rotated) — skip, never crash the chat turn.
-                logger.info("Skipping MCP connection %r: no usable credentials", connection.name)
-                continue
-            specs.append(
-                McpServerSpec(
-                    name=connection.name,
-                    url=connection.url,
-                    headers=headers,
-                    allowed_tools=connection.allowed_tools,
-                )
+    if user_id is not None:
+        async with get_db_context() as db:
+            connections, _ = await mcp_connection_repo.list_for_user(
+                db, user_id=user_id, enabled_only=True
             )
+            for connection in connections:
+                headers = await _resolve_auth_headers(db, connection)
+                if headers is None:
+                    # OAuth not authorized / expired, or an undecryptable bearer
+                    # token (e.g. SECRET_KEY rotated) — skip, never crash the turn.
+                    logger.info(
+                        "Skipping MCP connection %r: no usable credentials", connection.name
+                    )
+                    continue
+                specs.append(
+                    McpServerSpec(
+                        name=connection.name,
+                        url=connection.url,
+                        headers=headers,
+                        allowed_tools=connection.allowed_tools,
+                    )
+                )
     return await build_mcp_toolsets(specs)

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_mcp_connections.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_mcp_connections.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import httpx
 import pytest
 from mcp.shared.auth import OAuthToken
+from pydantic import ValidationError
 
 from app.agents import mcp_oauth
 from app.agents.mcp import (
@@ -256,6 +257,51 @@ class TestStaticServerSpecs:
             )
         ]
 
+    def test_name_must_be_a_slug(self):
+        """The name becomes the tool prefix, so anything outside the slug rule
+        would silently collapse two servers onto one prefix."""
+        with pytest.raises(ValidationError):
+            McpServerConfig(name="My Server!", url="https://example.com/mcp")
+
+    def test_duplicate_names_are_rejected_at_startup(self):
+        """Two servers with one name means one of them never reaches a chat
+        turn. Fail at boot rather than at runtime, where nobody would see it."""
+        with pytest.raises(ValidationError, match="duplicate server names"):
+            type(settings)(
+                MCP_SERVERS=[
+                    McpServerConfig(name="github", url="https://a.example/mcp"),
+                    McpServerConfig(name="github", url="https://b.example/mcp"),
+                ]
+            )
+
+
+class TestToolsetsForUser:
+    @pytest.mark.anyio
+    async def test_no_user_still_gets_workspace_servers(self, monkeypatch):
+        """Channel traffic that isn't mapped to an account: the deployment's
+        MCP_SERVERS still apply, and no database session is opened for the
+        per-user connections that can't exist."""
+
+        def _no_db():  # pragma: no cover - only called if the guard regresses
+            raise AssertionError("build_toolsets_for_user(None) must not open a session")
+
+        monkeypatch.setattr(
+            mcp_connection_service,
+            "static_server_specs",
+            lambda: [McpServerSpec(name="workspace", url="https://example.com/mcp")],
+        )
+        monkeypatch.setattr(mcp_connection_service, "get_db_context", _no_db)
+        seen: list[list[McpServerSpec]] = []
+
+        async def fake_build(specs: list[McpServerSpec]) -> list[str]:
+            seen.append(specs)
+            return ["toolset"]
+
+        monkeypatch.setattr(mcp_connection_service, "build_mcp_toolsets", fake_build)
+
+        assert await mcp_connection_service.build_toolsets_for_user(None) == ["toolset"]
+        assert [spec.name for spec in seen[0]] == ["workspace"]
+
 
 class TestAuthHeaders:
     @pytest.mark.anyio
@@ -285,6 +331,7 @@ def _oauth_connection(payload: McpOAuthPayload, **overrides) -> McpConnection:
 def _base_payload(**overrides) -> McpOAuthPayload:
     data = {
         "server_url": "https://srv/mcp",
+        "started_at": datetime.now(UTC).timestamp(),
         "authorization_endpoint": "https://srv/authorize",
         "token_endpoint": "https://srv/token",
         "client_id": "cid",
@@ -339,12 +386,18 @@ class TestOAuthTokens:
         fresh = OAuthToken(access_token="fresh-token", refresh_token="rt2", expires_in=3600)
         refresh_mock = AsyncMock(return_value=fresh)
         monkeypatch.setattr(mcp_oauth, "refresh_tokens", refresh_mock)
+        lock_mock = AsyncMock(return_value=conn)
+        monkeypatch.setattr(
+            mcp_connection_service.mcp_connection_repo, "get_by_id_for_update", lock_mock
+        )
         update_mock = AsyncMock()
         monkeypatch.setattr(mcp_connection_service.mcp_connection_repo, "update", update_mock)
 
         headers = await _resolve_auth_headers(AsyncMock(), conn)
         assert headers == {"Authorization": "Bearer fresh-token"}
         refresh_mock.assert_awaited_once()
+        # The refresh token is only ever spent while holding the row lock.
+        lock_mock.assert_awaited_once()
         # The refreshed token was persisted back (re-encrypted).
         stored = update_mock.call_args.kwargs["update_data"]["oauth_payload"]
         assert (
@@ -353,6 +406,39 @@ class TestOAuthTokens:
             ).access_token
             == "fresh-token"
         )
+
+    @pytest.mark.anyio
+    async def test_concurrent_turn_reuses_the_token_the_winner_stored(self, monkeypatch):
+        """Two turns can hit an expired token at once. The one that loses the
+        row lock must re-read the row and use the fresh token, not spend the
+        refresh token a second time — providers that rotate it would invalidate
+        the winner's copy and quietly kill the connection."""
+        stale = _oauth_connection(
+            _base_payload(access_token="stale", refresh_token="rt", expires_at=0.0)
+        )
+        # What the winner committed while we waited on the lock.
+        refreshed = _oauth_connection(
+            _base_payload(
+                access_token="fresh-token",
+                refresh_token="rt2",
+                expires_at=datetime.now(UTC).timestamp() + 3600,
+            )
+        )
+        refresh_mock = AsyncMock()
+        monkeypatch.setattr(mcp_oauth, "refresh_tokens", refresh_mock)
+        monkeypatch.setattr(
+            mcp_connection_service.mcp_connection_repo,
+            "get_by_id_for_update",
+            AsyncMock(return_value=refreshed),
+        )
+        update_mock = AsyncMock()
+        monkeypatch.setattr(mcp_connection_service.mcp_connection_repo, "update", update_mock)
+
+        headers = await _resolve_auth_headers(AsyncMock(), stale)
+
+        assert headers == {"Authorization": "Bearer fresh-token"}
+        refresh_mock.assert_not_awaited()
+        update_mock.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_expired_token_without_refresh_yields_none(self):
@@ -506,6 +592,8 @@ class TestMcpConnectionService:
         )
         assert payload.code_verifier and payload.access_token is None
         assert payload.client_id == "cid"
+        # Stamped so the callback can refuse a flow the user never finished.
+        assert datetime.now(UTC).timestamp() - payload.started_at < mcp_oauth.FLOW_TTL_SECS
 
     @pytest.mark.anyio
     async def test_oauth_start_keeps_working_tokens_until_consent(
@@ -581,6 +669,44 @@ class TestMcpConnectionService:
         repo.get_by_oauth_state = AsyncMock(return_value=None)
         with pytest.raises(NotFoundError):
             await service.oauth_callback(state="nope", code="x")
+
+    @pytest.mark.anyio
+    async def test_oauth_callback_rejects_an_expired_flow(self, service, repo, monkeypatch):
+        """The state token is the only thing authenticating this endpoint, and
+        it travels through the provider and the browser's history — a consent
+        redirect the user never finished must stop being redeemable."""
+        started = datetime.now(UTC).timestamp() - mcp_oauth.FLOW_TTL_SECS - 1
+        stale = _connection(
+            auth_type="oauth",
+            oauth_state="state-old",
+            oauth_pending_payload=encrypt_value(
+                _base_payload(code_verifier="verifier", started_at=started).model_dump_json(),
+                settings.SECRET_KEY,
+            ),
+        )
+        repo.get_by_oauth_state = AsyncMock(return_value=stale)
+        exchange_mock = AsyncMock()
+        monkeypatch.setattr(mcp_oauth, "exchange_code", exchange_mock)
+
+        with pytest.raises(mcp_oauth.OAuthError, match="expired"):
+            await service.oauth_callback(state="state-old", code="the-code")
+
+        exchange_mock.assert_not_awaited()
+        repo.update.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_oauth_callback_on_unreadable_payload_asks_to_start_again(self, service, repo):
+        """A rotated SECRET_KEY makes the pending payload undecryptable. That's
+        a dead flow the user restarts, not a 500."""
+        stale = _connection(
+            auth_type="oauth",
+            oauth_state="state-broken",
+            oauth_pending_payload="enc:not-valid-ciphertext",
+        )
+        repo.get_by_oauth_state = AsyncMock(return_value=stale)
+
+        with pytest.raises(mcp_oauth.OAuthError, match="no longer valid"):
+            await service.oauth_callback(state="state-broken", code="the-code")
 
     @pytest.mark.anyio
     async def test_update_url_drops_oauth_tokens(self, service, repo, monkeypatch):

--- a/template/{{cookiecutter.project_slug}}/frontend/src/components/settings/mcp-connections-manager.tsx
+++ b/template/{{cookiecutter.project_slug}}/frontend/src/components/settings/mcp-connections-manager.tsx
@@ -30,7 +30,7 @@ import { ApiError } from "@/lib/api-client";
 import { useMcpConnections } from "@/hooks";
 import {
   catalogBaseUrl,
-  logoUrl,
+  logoDataUri,
   MCP_CATALOG,
   MCP_CATEGORIES,
   type McpCatalogEntry,
@@ -62,10 +62,11 @@ function PluginLogo({ entry }: { entry: McpCatalogEntry }) {
     );
   }
   return (
-    // Plain <img> (not next/image) so no remote-domain config is needed for a favicon-sized asset.
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/no-noninteractive-element-interactions
+    // Plain <img> (not next/image) — the source is an inlined data URI, so
+    // there's nothing for the image optimizer to fetch or cache.
+    // eslint-disable-next-line @next/next/no-img-element
     <img
-      src={logoUrl(entry.domain)}
+      src={logoDataUri(entry.domain)}
       alt=""
       width={22}
       height={22}
@@ -109,6 +110,7 @@ export function McpConnectionsManager() {
     queryKey: qk.mcpConnections.workspace(),
     queryFn: listWorkspaceMcpServers,
   });
+  const workspaceNames = new Set(workspaceServers.map((server) => server.name));
 
   // Surface the result of an OAuth redirect (see the /oauth/callback route),
   // then strip the query params so a page refresh doesn't re-toast.
@@ -197,9 +199,11 @@ export function McpConnectionsManager() {
         setEditingId(null);
         void handleEditTools(created);
       } else if (editingId) {
+        // Send only what actually changed — re-sending the same URL would reset
+        // the connection's last-checked status for no reason.
         await update(editingId, {
-          name,
-          url,
+          ...(name !== editing?.name ? { name } : {}),
+          ...(url !== editing?.url ? { url } : {}),
           // Omit auth_token to keep the stored one; "" clears it.
           ...(token ? { auth_token: token } : clearToken ? { auth_token: "" } : {}),
         });
@@ -422,6 +426,10 @@ export function McpConnectionsManager() {
                     {entries.map((entry) => {
                       const existing = connectionFor(entry);
                       const busy = connectingId === entry.id;
+                      // A workspace server claims the tool prefix this entry
+                      // would use, so a personal connection under the same name
+                      // would be dropped from every turn. Say so instead.
+                      const shadowed = workspaceNames.has(entry.id);
                       // An OAuth connection that hasn't finished consent isn't
                       // really connected yet — offer to finish signing in.
                       const needsAuth =
@@ -454,7 +462,12 @@ export function McpConnectionsManager() {
                                     ? "Your personal link"
                                     : "Token required"}
                             </span>
-                            {existing && !needsAuth ? (
+                            {shadowed ? (
+                              <span className="text-foreground/65 inline-flex items-center gap-1 text-xs font-medium">
+                                <Building2 className="text-foreground/45 h-3.5 w-3.5" />
+                                Provided by your workspace
+                              </span>
+                            ) : existing && !needsAuth ? (
                               <span className="text-foreground/65 inline-flex items-center gap-1 text-xs font-medium">
                                 <Check className="h-3.5 w-3.5 text-emerald-500" />
                                 Connected

--- a/template/{{cookiecutter.project_slug}}/frontend/src/lib/mcp-catalog.ts
+++ b/template/{{cookiecutter.project_slug}}/frontend/src/lib/mcp-catalog.ts
@@ -27,7 +27,7 @@ export interface McpCatalogEntry {
   /** Which section heading this card appears under. */
   category: McpCatalogCategory;
   title: string;
-  /** Brand domain used to fetch the color logo (see {@link logoUrl}). */
+  /** Brand domain the color logo is keyed by (see {@link logoDataUri}). */
   domain: string;
   description: string;
   /**
@@ -54,24 +54,26 @@ export function catalogBaseUrl(url: string): string {
 }
 
 /**
- * Color logo for a brand domain via Google's favicon service — tokenless and
- * served over HTTPS. Returns the brand mark; the card falls back to an initial
- * avatar if the request fails. `sz=128` keeps it crisp when scaled to the avatar.
+ * Last-resort logo source: Google's favicon service, tokenless and over HTTPS.
+ * Only reached for a domain missing from {@link MCP_LOGOS} — every catalog
+ * entry should be baked in, so hitting this means `bun run gen:mcp-logos`
+ * needs a re-run. Not exported: nothing should request it on purpose.
  */
-export function logoUrl(domain: string): string {
+function faviconServiceUrl(domain: string): string {
   return `https://www.google.com/s2/favicons?sz=128&domain=${encodeURIComponent(domain)}`;
 }
 
 /**
- * Brand logo for a catalog domain, preferring the baked-in data URI
- * ({@link MCP_LOGOS}) so it renders OFFLINE in the self-contained demo export.
- * Falls back to the live favicon service for domains not baked (regenerate the
- * map with `bun run gen:mcp-logos` after adding a catalog entry). Used by the
- * demo-only MCP badge; the Settings marketplace keeps {@link logoUrl} (always
- * online, higher-res).
+ * Brand logo for a catalog domain, as a baked-in data URI ({@link MCP_LOGOS}).
+ *
+ * Used everywhere a catalog logo is shown — the Settings marketplace and the
+ * demo-only MCP badge alike. Baked rather than fetched for two reasons: the
+ * self-contained export has no network, and a live app shouldn't tell a third
+ * party which plugins its users are looking at. Regenerate the map with
+ * `bun run gen:mcp-logos` after adding a catalog entry.
  */
 export function logoDataUri(domain: string): string {
-  return MCP_LOGOS[domain] ?? logoUrl(domain);
+  return MCP_LOGOS[domain] ?? faviconServiceUrl(domain);
 }
 
 /** Catalog id / connection name → tool prefix (mirrors the backend `_tool_prefix`). */

--- a/tests/test_template_integration.py
+++ b/tests/test_template_integration.py
@@ -297,12 +297,15 @@ MATRIX_CONFIGS: dict[str, dict] = {
     ),
     # MCP client: agents/mcp*, the connections service/repo/routes and the
     # OAuth flow only render under this flag — without a matrix entry none of
-    # that backend code is ever linted or type-checked.
+    # that backend code is ever linted or type-checked. Slack is on because
+    # agent_invocation.py is the second place the agent gets MCP toolsets and
+    # it only renders for a channel build.
     "pydantic_ai_mcp_client": dict(
         database=DatabaseType.POSTGRESQL,
         ai_framework=AIFrameworkType.PYDANTIC_AI,
         enable_logfire=False,
         enable_mcp_client=True,
+        use_slack=True,
         frontend=FrontendType.NEXTJS,
         background_tasks=BackgroundTaskType.NONE,
     ),


### PR DESCRIPTION
Follow-up to #124. Everything here is a gap in the MCP client that survived the first round of review — most of it invisible because no CI job ever rendered the feature.

## The one that hid the rest

**There was no CI job that generates with `--mcp-client`.** The matrix entry in `test_template_integration.py` runs `ruff` + `ty` and nothing else, so the generated project's own MCP test suite and the frontend `tsc`/`eslint` never ran against an MCP build. This PR adds `Template - PostgreSQL + MCP Client`, which renders the project, runs the backend lint/type/pytest and the frontend lint/type-check/tests. It renders with `--slack` too, because `agent_invocation.py` only exists for a channel build — and that file turned out to matter (below).

## Correctness

**Channel bots got no MCP tools.** `agent_invocation.py` is the second place the PydanticAI agent is built, and it was the one that didn't attach the user's toolsets. A plugin worked in web chat and did nothing in Slack/Telegram, with no error either way. `build_toolsets_for_user` now takes an optional `user_id`, so channel traffic with no mapped account still gets the deployment-managed `MCP_SERVERS`.

**Concurrent token refresh.** Two turns for the same user could both see an expired access token and both redeem the refresh token. Providers that rotate refresh tokens invalidate whichever copy is redeemed second, and the connection then stops working with nothing to point at. The refresh now happens under `SELECT ... FOR UPDATE`, so the loser waits, re-reads the row, and uses the token the winner stored. (Raised as a follow-up in the review on #124.)

**A consent redirect never expired.** The `state` token is the only thing authenticating the callback, and it travels through the provider and the browser's history. A flow the user abandoned stayed redeemable forever. It now expires after `FLOW_TTL_SECS`.

**An undecryptable pending payload was a 500.** Rotate `SECRET_KEY` mid-flow and the callback raised out of the route. It now tells the user to start again, same as every other dead-credential path in this module.

## Configuration that failed silently

`MCP_SERVERS` names are now validated as slugs and checked for duplicates at startup. The name *is* the server's tool prefix, so a stray character or a repeated name meant a server was quietly dropped from every chat turn — the one place where failing loud at boot is strictly better. The `.env.example` now suggests `github-internal`, which can't collide with the marketplace's `github`.

## Frontend

- The marketplace fetched 14 favicons from `google.com/s2/favicons` on every settings page view. The logos are already baked in as data URIs for the offline export — it now uses those everywhere, so the app doesn't tell a third party which plugins its users are browsing.
- A catalog entry whose name a workspace server already claims now reads "Provided by your workspace" instead of offering a Connect button that would create a connection dropped on every turn.
- Editing a connection sends only what changed, so renaming one no longer resets its last-checked status.

## Verification

- Generator: `ruff`, `ty`, `pytest` (349 passed) green; the MCP matrix entry passes.
- Render **on** (`pydantic_ai` + postgres + frontend + slack): backend `ruff`/`ty` clean, 230 backend tests pass, single Alembic head; frontend `tsc` clean, `eslint` 0 errors, unit tests pass.
- Render **off**: no MCP residue, backend and frontend both clean.
