### PR TITLE
fix(template): unbreak generated projects against upstream releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Every generated project with pagination failed to start** — `fastapi-pagination` 0.15.16 probes for FastAPI's private `_get_body_field` / `_get_flat_body_params` helpers to decide which signature to call, and its `ImportError` fallback binds the *public* `get_body_field` while still setting `_get_body_field_new_signature = True`. On any FastAPI below 0.140.5 — which the template's `fastapi>=0.135.3,<0.137` pin guarantees — `add_pagination(app)` therefore calls it with a `body_params` kwarg it does not accept, and `app.main` raises `TypeError` on import. Nothing in the generated project was wrong; the release landed 2026-07-28 and took every template CI job with it. Pinned `fastapi-pagination<0.15.16` until upstream fixes the fallback or the FastAPI pin moves past 0.140.5
+- **The DeepAgents backend was constructed with an argument it no longer takes** — `deepagents` 0.7 dropped the runtime parameter from `StateBackend.__init__` and changed `create_deep_agent` to accept a backend *instance* rather than a factory, so `lambda rt: StateBackend(rt)` was wrong twice over: `ty` rejected the call, and the first agent invocation would have raised `TypeError`. `_create_backend` now returns `StateBackend()` typed as `BackendProtocol`, and the dependency is capped `<0.8` — that API has moved between minors, and unbounded pins turn an upstream release into a broken generation
+- **`RedisClient.get` leaned on a `type: ignore` that stopped applying** — `connect()` passes `decode_responses=True`, but redis-py's annotation cannot express that and still admits `bytes`, so the declared `str | None` was a claim the type checker had no reason to accept. The value is now decoded explicitly instead of being asserted through a suppression
+
 ## [0.2.17] - 2026-07-25
 
 ### Added

--- a/template/{{cookiecutter.project_slug}}/backend/app/agents/deepagents_assistant.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/agents/deepagents_assistant.py
@@ -25,11 +25,10 @@ Configuration via settings:
 """
 
 import logging
-from collections.abc import Callable
 from typing import Any, TypedDict
 
 from deepagents import create_deep_agent
-from deepagents.backends import StateBackend
+from deepagents.backends import BackendProtocol, StateBackend
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 {%- if cookiecutter.enable_rag or cookiecutter.enable_web_search or cookiecutter.web_fetch_tool or cookiecutter.enable_charts %}
@@ -307,13 +306,17 @@ class DeepAgentsAssistant:
         self._graph = None
         self._checkpointer = MemorySaver()
 
-    def _create_backend(self) -> Callable:
+    def _create_backend(self) -> BackendProtocol:
         """Create the file-storage backend.
 
+        `create_deep_agent` takes a backend instance, and StateBackend reads the
+        current run's state out of the LangGraph config itself, so it needs no
+        constructor argument.
+
         Returns:
-            BackendFactory (callable) for StateBackend (in-memory, ephemeral).
+            StateBackend (in-memory file state, ephemeral, no external deps).
         """
-        return lambda rt: StateBackend(rt)
+        return StateBackend()
 
     def _create_model(self) -> BaseChatModel:
         """Create the LLM model for DeepAgents."""

--- a/template/{{cookiecutter.project_slug}}/backend/app/clients/redis.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/clients/redis.py
@@ -39,10 +39,18 @@ class RedisClient:
             self.client = None
 
     async def get(self, key: str) -> str | None:
-        """Get a value by key."""
+        """Get a value by key.
+
+        `connect()` sets decode_responses=True, so the value comes back decoded —
+        but redis-py's annotation cannot express that and still admits `bytes`.
+        Decode explicitly rather than asserting the flag through a type: ignore.
+        """
         if not self.client:
             raise RuntimeError("Redis client not connected")
-        return await self.client.get(key)  # type: ignore[no-any-return]
+        value: str | bytes | None = await self.client.get(key)
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
 
     async def set(
         self,

--- a/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
+++ b/template/{{cookiecutter.project_slug}}/backend/pyproject.toml
@@ -75,7 +75,13 @@ dependencies = [
     "aiosmtplib>=3.0.0",
 {%- endif %}
 {%- if cookiecutter.enable_pagination %}
-    "fastapi-pagination>=0.12.31",
+    # 0.15.16 is broken against every FastAPI without the private _get_body_field
+    # helpers (i.e. anything below 0.140.5, which includes the pin above): its
+    # ImportError fallback binds the public get_body_field but still sets
+    # _get_body_field_new_signature = True, so add_pagination() calls it with a
+    # body_params kwarg it does not accept and the app dies on import. Lift the
+    # cap once upstream fixes the fallback or the FastAPI pin moves past 0.140.5.
+    "fastapi-pagination>=0.12.31,<0.15.16",
 {%- endif %}
 {%- if cookiecutter.enable_sentry %}
     "sentry-sdk[fastapi]>=2.53.0",
@@ -154,7 +160,11 @@ dependencies = [
     "langgraph-checkpoint>=4.0.0",
 {%- endif %}
 {%- if cookiecutter.use_deepagents %}
-    "deepagents>=0.1.0",
+    # Capped: the backend API is still moving between minors (0.7 dropped the
+    # runtime argument from StateBackend and switched create_deep_agent to take
+    # an instance instead of a factory), so an unbounded pin breaks generation
+    # on release day.
+    "deepagents>=0.7.1,<0.8",
 {%- if cookiecutter.use_openai %}
     "langchain-openai>=1.1.0",
 {%- endif %}


### PR DESCRIPTION
CI has been red on `main` since 2026-07-28 (run [30694949242](https://github.com/vstorm-co/full-stack-ai-agent-template/actions/runs/30694949242) on #134 — 21 jobs). Two upstream releases landed that day, and one of them stops every generated project from booting. Found while looking at why #135's checks were failing; none of this is caused by that PR.

## 1. `fastapi-pagination` 0.15.16 breaks every generated app at import

Not a version-cap problem on our side — a bug in their release. 0.15.16 probes for FastAPI's private helpers to pick a call signature:

```python
try:
    from fastapi.dependencies.utils import _get_body_field as get_body_field
    from fastapi.dependencies.utils import _get_flat_body_params as get_flat_body_params
    _get_body_field_new_signature = True
    ...
except ImportError:
    from fastapi.dependencies.utils import get_body_field   # public, OLD signature
    ...
    _get_body_field_new_signature = True                    # <-- still True
```

The fallback binds the public function and leaves the flag `True`, so on any FastAPI without the private helpers — anything below 0.140.5, which our `fastapi>=0.135.3,<0.137` pin guarantees — `add_pagination(app)` calls it with a `body_params` kwarg it does not accept:

```
TypeError: get_body_field() got an unexpected keyword argument 'body_params'
```

That is an import-time failure in `app.main`, so it is not only CI: anyone who generated a project with pagination in the last few days has an app that will not start.

Pinned `fastapi-pagination>=0.12.31,<0.15.16`. Verified with a minimal `add_pagination` app against fastapi 0.136.3: 0.15.15 fine, 0.15.16 raises. After the pin, a rendered project imports (`app imported OK, routes: 63`) and its own suite is 178 passed (the 4 `test_migrations` failures locally are my dirty local database — they skip cleanly against a fresh one, and CI uses a per-job postgres service).

## 2. DeepAgents backend constructed with an argument it no longer takes

`deepagents` 0.7 dropped the runtime parameter from `StateBackend.__init__` and changed `create_deep_agent` to accept a backend **instance** rather than a factory, so `lambda rt: StateBackend(rt)` was wrong twice over — `ty` rejected the call, and the first agent invocation would have raised `TypeError` too. `_create_backend` now returns `StateBackend()` typed as `BackendProtocol` (the instance is what `create_deep_agent(backend=...)` wants, and `StateBackend` reads the run's state from the LangGraph config itself).

Capped `deepagents>=0.7.1,<0.8`: that API has moved between minors, and an unbounded pin turns an upstream release into a broken generation with no warning.

Smoke-tested on a rendered DeepAgents project — the backend satisfies `BackendProtocol` and `assistant.graph` compiles to a `CompiledStateGraph`.

## 3. `RedisClient.get` leaned on a stale suppression

`connect()` passes `decode_responses=True`, but redis-py's annotation cannot express that and still admits `bytes`, so the declared `str | None` was a claim `# type: ignore[no-any-return]` was hiding rather than justifying. The value is decoded explicitly now — correct in both configurations, no suppression.

## Verification

Full local suite: **674 passed, 5 skipped, 0 failed** (`main` is 2 failed — exactly the two `test_passes_ty[deepagents_*]` jobs above).

## Note

The RAG template job prints 20 further `ty` diagnostics (e.g. `collection_name: str | None` passed to a `str` parameter in `app/commands/`), but `ty` is advisory in those jobs so they do not fail the build. Left out of this PR deliberately — separate scope, and worth its own pass since at least one of them looks like a real latent bug.

Once this lands I will rebase #135, which should then go green.
