### PR TITLE
chore(release): 0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.18] - 2026-08-01
 
 ### Fixed
 

--- a/UPGRADES.yaml
+++ b/UPGRADES.yaml
@@ -18,4 +18,8 @@
 #   manual_steps:
 #     - "Run `alembic upgrade head` (new billing tables)."
 
-[]
+- version: "0.2.18"
+  manual_steps:
+    - "Rebuild the frontend image: `docker compose -f docker-compose.prod.yml build --no-cache frontend`. NEXT_PUBLIC_* is inlined into the browser bundle at build time and now comes from compose build args, so an image built before this upgrade still has the old ws://localhost URL baked in."
+    - "Serving the frontend over plain http:// with no TLS? Set COOKIE_SECURE=false on the frontend service. The auth cookies are Secure in production and a browser discards a Secure cookie sent over http://, which makes login appear to succeed while every request after it returns 401."
+    - "BACKEND_WS_URL and NEXT_PUBLIC_AUTH_ENABLED were never read by any code and are gone from the env examples. If your deployment sets them, the browser-facing WebSocket origin is NEXT_PUBLIC_WS_URL (build-time)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-fullstack"
-version = "0.2.17"
+version = "0.2.18"
 description = "Full-stack FastAPI + Next.js template generator with PydanticAI/LangChain agents, WebSocket streaming, 20+ enterprise integrations, and Logfire/LangSmith observability. Ship AI apps fast. CLI tool to generate production-ready FastAPI + Next.js projects with AI agents, auth, and observability."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-fullstack"
-version = "0.2.17"
+version = "0.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Version bump + CHANGELOG for 0.2.18. Contents: #135 (Docker deployments off localhost, closes #132) and #136 (upstream releases that stopped generated projects from starting).

`UPGRADES.yaml` gets a 0.2.18 block with the manual steps the upgrade tool cannot do for the client:

- rebuild the frontend image, or the old `ws://localhost` stays baked into the bundle
- `COOKIE_SECURE=false` for a plain-`http://` deployment
- `BACKEND_WS_URL` / `NEXT_PUBLIC_AUTH_ENABLED` are gone; the browser-facing var is `NEXT_PUBLIC_WS_URL`

`record_renames.py` reports no moves, and the rename guard passes locally.