### PR TITLE
fix: restore working star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1383,7 +1383,7 @@ Yes. The LLM provider is configured via environment variables (`AI_MODEL`, `OPEN
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vstorm-co/full-stack-fastapi-nextjs-llm-template&type=date&legend=top-left)](https://www.star-history.com/#vstorm-co/full-stack-fastapi-nextjs-llm-template&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vstorm-co/full-stack-fastapi-nextjs-llm-template&type=date&legend=top-left)](https://star-history.dera.page/#vstorm-co/full-stack-fastapi-nextjs-llm-template&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is broken: the current endpoint stops rendering under GitHub's stargazer API restrictions, so visitors see no chart. This updates the chart image and link to the new star-history.dera.page host, which serves the same chart from an alternative data source that needs no API token. Fixing it is necessary so the project's popularity stays visible on the landing page.